### PR TITLE
scripts: install/remove - Disable dnsmasq listen on tun0 interface

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -158,6 +158,9 @@ sudo sed 's|<TPL:PHP_USER>|admin|g' -i /etc/php5/fpm/pool.d/vpnadmin.conf
 sudo sed 's|<TPL:PHP_GROUP>|admins|g' -i /etc/php5/fpm/pool.d/vpnadmin.conf
 sudo sed 's|<TPL:NGINX_REALPATH>|/var/www/vpnadmin/|g' -i /etc/php5/fpm/pool.d/vpnadmin.conf
 
+## dnsmasq
+sudo sed 's|#except-interface=|except-interface=tun0|g' -i /etc/dnsmasq.conf
+
 # Fix sources
 sudo sed "s|<TPL:NGINX_LOCATION>|${url_path}|g" -i /var/www/vpnadmin/config.php
 

--- a/scripts/remove
+++ b/scripts/remove
@@ -31,6 +31,9 @@ sudo rm -f /etc/openvpn/client.conf{.tpl,.tpl.restore,}
 sudo rm -f /etc/nginx/conf.d/${domain}.d/vpnadmin.conf
 sudo rm -f /etc/php5/fpm/pool.d/vpnadmin.conf
 
+# Clean dnsmasq confs
++sudo sed 's|except-interface=tun0|#except-interface=|g' -i /etc/dnsmasq.conf
+
 # Remove certificates
 sudo rm -rf /etc/openvpn/keys/
 


### PR DESCRIPTION
Added a dnsmasq configuration snippet to disable the listening on tunnel
interface. The tunnel (tun0) interface is generally public, and by
default the firewall is open on this interface. In order to not
participate to DNS amplification attacks, this commit disable the tun0
interface listening.