### PR TITLE
Replace occurrences of Server Address with Server Name

### DIFF
--- a/sources/controller.php
+++ b/sources/controller.php
@@ -142,7 +142,7 @@ dispatch_put('/settings', function() {
       $ip6_addr = 'none';
 
       if(empty($config['server_name']) || empty($config['server_port']) || empty($config['server_proto'])) {
-        throw new Exception(_('The Server Address, the Server Port and the Protocol cannot be empty'));
+        throw new Exception(_('The Server Name, the Server Port and the Protocol cannot be empty'));
       }
     
       if(!preg_match('/^\d+$/', $config['server_port'])) {

--- a/sources/i18n/fr_FR/LC_MESSAGES/localization.po
+++ b/sources/i18n/fr_FR/LC_MESSAGES/localization.po
@@ -24,9 +24,9 @@ msgid "Json Syntax Error, please check your dot cube file"
 msgstr "Error de syntaxe Json, merci de vérifier votre fichier .cube"
 
 #: sources/controller.php:140
-msgid "The Server Address, the Server Port and the Protocol cannot be empty"
+msgid "The Server Name, the Server Port and the Protocol cannot be empty"
 msgstr ""
-"L'adresse du serveur, le port du serveur et le protocole ne peuvent pas être "
+"Le nom du serveur, le port du serveur et le protocole ne peuvent pas être "
 "vides"
 
 #: sources/controller.php:144
@@ -147,8 +147,8 @@ msgid "VPN"
 msgstr "VPN"
 
 #: sources/views/settings.html.php:72
-msgid "Server Address"
-msgstr "Adresse du serveur"
+msgid "Server Name"
+msgstr "Nom du serveur"
 
 #: sources/views/settings.html.php:79
 msgid "Server Port"

--- a/sources/i18n/localization.pot
+++ b/sources/i18n/localization.pot
@@ -22,7 +22,7 @@ msgid "Json Syntax Error, please check your dot cube file"
 msgstr ""
 
 #: sources/controller.php:140
-msgid "The Server Address, the Server Port and the Protocol cannot be empty"
+msgid "The Server Name, the Server Port and the Protocol cannot be empty"
 msgstr ""
 
 #: sources/controller.php:144
@@ -136,7 +136,7 @@ msgid "VPN"
 msgstr ""
 
 #: sources/views/settings.html.php:72
-msgid "Server Address"
+msgid "Server Name"
 msgstr ""
 
 #: sources/views/settings.html.php:79

--- a/sources/views/settings.html.php
+++ b/sources/views/settings.html.php
@@ -69,7 +69,7 @@
 
             <div style="padding: 14px 14px 0 10px">
               <div class="form-group">
-                <label for="server_name" class="col-sm-3 control-label"><?= _('Server Address') ?></label>
+                <label for="server_name" class="col-sm-3 control-label"><?= _('Server Name') ?></label>
                 <div class="col-sm-9">
                   <input type="text" class="form-control" name="server_name" id="server_name" placeholder="vpn.example.net" value="<?= $server_name ?>" />
                 </div>


### PR DESCRIPTION
Simple fix for https://dev.yunohost.org/issues/978

The configuration fails when using an IP address instead of a FQDN, since the
iptables scripts checks using dig whether the server name resolves to an IPv4
and/or IPv6.

To avoid confusion, replace occurrences of "Server Address" with "Server Name".