### PR TITLE
[fix] Add fake-hwclock to avoid RTC 1970 date

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
     "fr": "Client VPN"
   },
   "url": "https://github.com/labriqueinternet/vpnclient_ynh",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "AGPL-3.0",
   "maintainer": {
     "name": "Julien Vaubourg",

--- a/scripts/install
+++ b/scripts/install
@@ -32,7 +32,7 @@ fi
 ynh_webpath_register vpnclient $domain $url_path || ynh_die "problem on domain/path availability" 1
 
 # Install packages
-packages='php5-fpm sipcalc dnsutils openvpn curl'
+packages='php5-fpm sipcalc dnsutils openvpn curl fake-hwclock'
 export DEBIAN_FRONTEND=noninteractive
 
 sudo apt-get --assume-yes --force-yes install ${packages}


### PR DESCRIPTION
## The problem

Some times board reboot with the unix date (at 1970). VPN with certificate validation see the certificate has invalid has it is in future.

The time loss is probably due to an electrical shortage of several minutes/hours/days ?

## Solution
I suggest to setup fake-hwclock to registers the last date and set it early in the boot process.

## PR Status


## How to test

That's a good question

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 