### PR TITLE
[fix] ntpd blocked cause firewall to strict

### DIFF
--- a/conf/ynh-vpnclient
+++ b/conf/ynh-vpnclient
@@ -199,7 +199,7 @@ stop_openvpn() {
 
 sync_time() {
   systemctl stop ntp
-  ntpd -qg &> /dev/null
+  timeout 20 ntpd -qg &> /dev/null
   systemctl start ntp
 }
 


### PR DESCRIPTION
## The problem

It seems some router config block some port/protocole like ntp. In this case, it seems the function sync_time blocks the execution of the next part of the script

## Solution
Put a timeout on the command to avoid this issue if we are unable to synchronize time

## PR Status
Untested

## How to test

Configure your router firewall to drop udp and ntp port in 2 ways
Run this modified version and the unmodified version and see if there is a differences

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 