### PR TITLE
Reduce the noise during upgrade

### DIFF
--- a/scripts/backup
+++ b/scripts/backup
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+source ./helpers
+ynh_abort_if_errors       # Stop script if an error is detected
+
 backup_dir="${1}/apps/vpnclient"
 mkdir -p "${backup_dir}/"
 

--- a/scripts/install
+++ b/scripts/install
@@ -125,13 +125,13 @@ sudo systemctl restart php5-fpm
 
 sudo systemctl reload nginx
 
-sudo systemctl enable ynh-vpnclient
+sudo systemctl -q enable ynh-vpnclient
 sudo yunohost service add ynh-vpnclient
 
 ynh_systemctl start ynh-vpnclient-checker.service
-sudo systemctl enable ynh-vpnclient-checker.service
+sudo systemctl -q enable ynh-vpnclient-checker.service
 ynh_systemctl start ynh-vpnclient-checker.timer
-sudo systemctl enable ynh-vpnclient-checker.timer
+sudo systemctl -q enable ynh-vpnclient-checker.timer
 
 if ! $upgrade; then
   ynh_systemctl start ynh-vpnclient

--- a/scripts/install
+++ b/scripts/install
@@ -26,8 +26,10 @@ url_path=${2}
 
 source ./helpers
 
-# Check domain/path availability
-ynh_webpath_register vpnclient $domain $url_path || ynh_die "problem on domain/path availability" 1
+if ! $upgrade; then
+  # Check domain/path availability
+  ynh_webpath_register vpnclient $domain $url_path || ynh_die "problem on domain/path availability" 1
+fi
 
 # Install packages
 packages='php5-fpm sipcalc dnsutils openvpn curl fake-hwclock'

--- a/scripts/install
+++ b/scripts/install
@@ -24,9 +24,7 @@ upgrade=$([ "${VPNCLIENT_UPGRADE}" == 1 ] && echo true || echo false)
 domain=${1}
 url_path=${2}
 
-if ! $upgrade; then
-  source ./helpers
-fi
+source ./helpers
 
 # Check domain/path availability
 ynh_webpath_register vpnclient $domain $url_path || ynh_die "problem on domain/path availability" 1

--- a/scripts/install
+++ b/scripts/install
@@ -53,8 +53,8 @@ if ! $upgrade; then
   sudo yunohost app setting vpnclient server_proto -v udp
   sudo yunohost app setting vpnclient ip6_addr -v none
   sudo yunohost app setting vpnclient ip6_net -v none
-  sudo yunohost app setting vpnclient login_user -v "${login_user}"
-  sudo yunohost app setting vpnclient login_passphrase -v "${login_passphrase}"
+  sudo yunohost app setting vpnclient login_user -v ""
+  sudo yunohost app setting vpnclient login_passphrase -v ""
   sudo yunohost app setting vpnclient dns0 -v 89.234.141.66
   sudo yunohost app setting vpnclient dns1 -v 2001:913::8
 
@@ -130,9 +130,9 @@ sudo systemctl reload nginx
 sudo systemctl -q enable ynh-vpnclient
 sudo yunohost service add ynh-vpnclient
 
-ynh_systemctl start ynh-vpnclient-checker.service
+sudo systemctl -q start ynh-vpnclient-checker.service
 sudo systemctl -q enable ynh-vpnclient-checker.service
-ynh_systemctl start ynh-vpnclient-checker.timer
+sudo systemctl -q start ynh-vpnclient-checker.timer
 sudo systemctl -q enable ynh-vpnclient-checker.timer
 
 if ! $upgrade; then

--- a/scripts/install
+++ b/scripts/install
@@ -26,6 +26,8 @@ url_path=${2}
 
 source ./helpers
 
+ynh_abort_if_errors       # Stop script if an error is detected
+
 if ! $upgrade; then
   # Check domain/path availability
   ynh_webpath_register vpnclient $domain $url_path || ynh_die "problem on domain/path availability" 1

--- a/scripts/restore
+++ b/scripts/restore
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+source ./helpers
+ynh_abort_if_errors       # Stop script if an error is detected
+
 backup_dir="${1}/apps/vpnclient"
 
 sudo mkdir -p /etc/openvpn/

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -27,7 +27,7 @@ export VPNCLIENT_UPGRADE=1
 sudo bash /etc/yunohost/apps/vpnclient/scripts/remove &> /dev/null
 bash ./install "${domain}" "${path}" "${server_name}"
 
-sudo rmdir /etc/openvpn/keys/
+sudo rmdir --ignore-fail-on-non-empty /etc/openvpn/keys/
 sudo cp -a "${tmpdir}/keys/" /etc/openvpn/keys/
 sudo cp -a "${tmpdir}/settings.yml" /etc/yunohost/apps/vpnclient/
 sudo cp -a "${tmpdir}/client.conf.tpl" /etc/openvpn/ 2> /dev/null

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -8,6 +8,8 @@ ynh_setting() {
 
 source ./helpers
 
+ynh_abort_if_errors       # Stop script if an error is detected
+
 domain=$(ynh_setting vpnclient domain)
 path=$(ynh_setting vpnclient path)
 server_name=$(ynh_setting vpnclient server_name)


### PR DESCRIPTION
Upgrading the app produces a lot of useless and scary messages even if everything goes well actually.
More details here: https://dev.yunohost.org/issues/1104 

I couldn't get rid of all those so-called warnings. It would require ignoring stderr of some systemctl calls and I don't feel confident in doing something like this because it may hide real errors:

    sudo systemctl disable openvpn 2> /dev/null

With this PR the noise would be limited to something like this:
```
Attention : Mise à jour de l'application vpnclient...
Attention : Synchronizing state for openvpn.service with sysvinit using update-rc.d...
Attention : Executing /usr/sbin/update-rc.d openvpn defaults
Attention : insserv: warning: current start runlevel(s) (empty) of script `openvpn' overrides LSB defaults (2 3 4 5).
Attention : insserv: warning: current stop runlevel(s) (0 1 2 3 4 5 6) of script `openvpn' overrides LSB defaults (0 1 6).
Attention : Executing /usr/sbin/update-rc.d openvpn disable
Attention : insserv: warning: current start runlevel(s) (empty) of script `openvpn' overrides LSB defaults (2 3 4 5).
Attention : insserv: warning: current stop runlevel(s) (0 1 2 3 4 5 6) of script `openvpn' overrides LSB defaults (0 1 6).
Attention : Synchronizing state for php5-fpm.service with sysvinit using update-rc.d...
Attention : Executing /usr/sbin/update-rc.d php5-fpm defaults
Attention : Executing /usr/sbin/update-rc.d php5-fpm enable
Succès ! vpnclient a été mis à jour
Succès ! La configuration de SSOwat a été générée
Succès ! Mise à jour terminée
```