### PR TITLE
[fix] Sync the date with http if ntp can't

### DIFF
--- a/conf/ynh-vpnclient
+++ b/conf/ynh-vpnclient
@@ -200,6 +200,20 @@ stop_openvpn() {
 sync_time() {
   systemctl stop ntp
   timeout 20 ntpd -qg &> /dev/null
+  
+  # Some networks drop ntp port (udp 123). 
+  # Try to get the date with an http request on the internetcube web site
+  if [ $? -ne 0 ]; then
+    http_date=`curl -sD - labriqueinter.net | grep '^Date:' | cut -d' ' -f3-6`
+    http_date=`date -d "${http_date}" +%s`
+    current_date=`date +%s`
+
+    # Set the new date if it's greater than the current date
+    # So it does if 1970 year or if old fake-hwclock date is used
+    if [ $http_date -ge $current_date ]; then
+      date -s "${http_date}"
+    fi
+  fi 
   systemctl start ntp
 }
 

--- a/conf/ynh-vpnclient
+++ b/conf/ynh-vpnclient
@@ -205,12 +205,12 @@ sync_time() {
   # Try to get the date with an http request on the internetcube web site
   if [ $? -ne 0 ]; then
     http_date=`curl -sD - labriqueinter.net | grep '^Date:' | cut -d' ' -f3-6`
-    http_date=`date -d "${http_date}" +%s`
-    current_date=`date +%s`
+    http_date_seconds=`date -d "${http_date}" +%s`
+    curr_date_seconds=`date +%s`
 
     # Set the new date if it's greater than the current date
     # So it does if 1970 year or if old fake-hwclock date is used
-    if [ $http_date -ge $current_date ]; then
+    if [ $http_date_seconds -ge $curr_date_seconds ]; then
       date -s "${http_date}"
     fi
   fi 


### PR DESCRIPTION
## The problem

On some network ntp port is dropped, so ntpd can't sync the date. Fake hwclock date could be very old (internetcube shut down since a long time)

## Solution
Use http header to get the date, to do that we need a website, i suggest labriqueinter.net. Note if there is no DNS resolution, it doesn't work.

## PR Status
Untested

## How to test

Create a vm on a network without 123 port (or block it on yunohost firewall).
Set the date in 1980
Install vpnclient and configure it.
The von should be up

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 