### PR TITLE
[fix] Let VPN mount

### DIFF
--- a/conf/ynh-vpnclient
+++ b/conf/ynh-vpnclient
@@ -129,6 +129,10 @@ start_openvpn() {
     [ "${ynh_server_proto}" == tcp ] && proto=tcp-client
   fi
 
+  # Unset firewall to let DNS and NTP resolution works
+  # Firewall is reset after vpn is mounted (more details on #1016)
+  unset_firewall
+  
   sync_time
 
   cp /etc/openvpn/client.conf{.tpl,}


### PR DESCRIPTION
## The problem

In some case VPN can't mount due to (residual?) restrictive iptables rules.

## Solution
This should fix the VPN issues described on #1016 by disabling additionnal firewall rules before to mount the vpn.

## PR Status
Untested

## How to test



## Validation

- [x] Principle agreement 2/2 : Aleks Pitchum
- [x] Quick review 1/1 : Aleks
- [x] Simple test 1/1 : Pitchum
- [x] Deep review 1/1 : Pitchum
