### PR TITLE
Rework upgrade script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Created from https://github.com/YunoHost/example_ynh/blob/master/.gitignore
+*~
+*.sw[op]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: php
+
+before_script:
+    - git clone --depth 1 git://github.com/YunoHost/package_linter ../package_linter && cd ../package_linter
+    - mv ../vpnclient_ynh vpnclient_ynh
+
+script:
+    - ./package_linter.py vpnclient_ynh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: php
-
 before_script:
     - git clone --depth 1 git://github.com/YunoHost/package_linter ../package_linter && cd ../package_linter
     - mv ../vpnclient_ynh vpnclient_ynh
-
 script:
     - ./package_linter.py vpnclient_ynh
+notifications:
+  email: false
+  irc:
+    on_success: always
+    on_failure: always
+    channels:
+      - "irc.geeknode.org#labriqueinter.net-dev"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # VPN Client
+[![Build Status](https://travis-ci.org/labriqueinternet/vpnclient_ynh.svg?branch=master)](https://travis-ci.org/labriqueinternet/vpnclient_ynh)
 ## Overview
 
 VPN Client app for [YunoHost](http://yunohost.org/).

--- a/conf/ynh-vpnclient
+++ b/conf/ynh-vpnclient
@@ -199,7 +199,7 @@ stop_openvpn() {
 
 sync_time() {
   systemctl stop ntp
-  ntpd -qg &> /dev/null
+  timeout 20 ntpd -qg &> /dev/null
   systemctl start ntp
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,32 +1,46 @@
 {
   "name": "VPN Client",
   "id": "vpnclient",
+  "packaging_format": 1,
   "description": {
     "en": "VPN Client",
     "fr": "Client VPN"
   },
-  "license": "AGPL-3",
-  "developer": {
+  "url": "https://github.com/labriqueinternet/vpnclient_ynh",
+  "version": "1.0.0",
+  "license": "AGPL-3.0",
+  "maintainer": {
     "name": "Julien Vaubourg",
     "email": "julien@vaubourg.com",
     "url": "http://julien.vaubourg.com"
   },
-  "multi_instance": "false",
+  "requirements": {
+    "yunohost": ">= 2.2.0",
+    "moulinette": ">= 2.4.0"
+  },
+  "multi_instance": false,
+  "services": [
+    "nginx",
+    "php5-fpm",
+    "ynh-vpnclient"
+  ],
   "arguments": {
-    "install" : [
+    "install": [
       {
         "name": "domain",
+        "type": "domain",
         "ask": {
-            "en": "Choose a domain for the web administration",
-            "fr": "Choisissez un domaine pour l'administration web"
+          "en": "Choose a domain for the web administration",
+          "fr": "Choisissez un domaine pour l'administration web"
         },
         "example": "domain.org"
       },
       {
         "name": "path",
+        "type": "path",
         "ask": {
-            "en": "Choose a path for the web administration",
-            "fr": "Choisissez un chemin pour l'administration web"
+          "en": "Choose a path for the web administration",
+          "fr": "Choisissez un chemin pour l'administration web"
         },
         "example": "/vpnadmin",
         "default": "/vpnadmin"

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
     "fr": "Client VPN"
   },
   "url": "https://github.com/labriqueinternet/vpnclient_ynh",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "license": "AGPL-3.0",
   "maintainer": {
     "name": "Julien Vaubourg",

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
     "fr": "Client VPN"
   },
   "url": "https://github.com/labriqueinternet/vpnclient_ynh",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "AGPL-3.0",
   "maintainer": {
     "name": "Julien Vaubourg",

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
     "fr": "Client VPN"
   },
   "url": "https://github.com/labriqueinternet/vpnclient_ynh",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "AGPL-3.0",
   "maintainer": {
     "name": "Julien Vaubourg",

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
-
-source /usr/share/yunohost/helpers
-
 #
+# Common variables
+#
+
+pkg_dependencies="php5-fpm sipcalc dnsutils openvpn curl fake-hwclock"
+
+
 # Helper to start/stop/.. a systemd service from a yunohost context,
 # *and* the systemd service itself needs to be able to run yunohost
 # commands.
-# 
+#
 # Hence the need to release the lock during the operation
 #
 # usage : ynh_systemctl yolo restart
@@ -24,7 +27,7 @@ function ynh_systemctl()
   # Save and release the lock...
   cp $LOCKFILE $LOCKFILE.bkp.$$
   rm $LOCKFILE
-  
+
   # Wait for the end of the action
   wait $SYSCTLACTION
 
@@ -37,3 +40,4 @@ function ynh_systemctl()
   # Restore the old lock
   mv $LOCKFILE.bkp.$$ $LOCKFILE
 }
+

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -6,6 +6,20 @@
 pkg_dependencies="php5-fpm sipcalc dnsutils openvpn curl fake-hwclock"
 
 
+# Experimental helpers
+# Cf. https://github.com/YunoHost-Apps/Experimental_helpers/blob/72b0bc77c68d4a4a2bf4e95663dbc05e4a762a0a/ynh_read_manifest/ynh_read_manifest
+read_json () {
+    sudo python3 -c "import sys, json;print(json.load(open('$1'))['$2'])"
+}
+read_manifest () {
+    if [ -f '../manifest.json' ] ; then
+        read_json '../manifest.json' "$1"
+    else
+        read_json '../settings/manifest.json' "$1"
+    fi
+}
+
+
 # Helper to start/stop/.. a systemd service from a yunohost context,
 # *and* the systemd service itself needs to be able to run yunohost
 # commands.

--- a/scripts/backup
+++ b/scripts/backup
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+#=================================================
+# MANAGE SCRIPT FAILURE
+#=================================================
+
+ynh_abort_if_errors # Stop script if an error is detected
+
+#=================================================
+
 backup_dir="${1}/apps/vpnclient"
 mkdir -p "${backup_dir}/"
 

--- a/scripts/backup
+++ b/scripts/backup
@@ -1,16 +1,61 @@
 #!/bin/bash
 
 #=================================================
+# GENERIC START
+#=================================================
+# IMPORT GENERIC HELPERS
+#=================================================
+
+if [ ! -e _common.sh ]; then
+	# Get the _common.sh file if it's not in the current directory
+	cp ../settings/scripts/_common.sh ./_common.sh
+	chmod a+rx _common.sh
+fi
+source _common.sh
+source /usr/share/yunohost/helpers
+
+#=================================================
 # MANAGE SCRIPT FAILURE
 #=================================================
 
 ynh_abort_if_errors # Stop script if an error is detected
 
 #=================================================
+# LOAD SETTINGS
+#=================================================
 
-backup_dir="${1}/apps/vpnclient"
-mkdir -p "${backup_dir}/"
+app=$YNH_APP_INSTANCE_NAME
 
-sudo cp -a /etc/openvpn/keys/ "${backup_dir}/"
-sudo cp -a /etc/openvpn/client.conf.tpl "${backup_dir}/"
+final_path=$(ynh_app_setting_get $app final_path)
+domain=$(ynh_app_setting_get $app domain)
+
+#=================================================
+# STANDARD BACKUP STEPS
+#=================================================
+# BACKUP THE APP MAIN DIR
+#=================================================
+
+ynh_backup "$final_path"
+
+#=================================================
+# BACKUP THE NGINX CONFIGURATION
+#=================================================
+
+ynh_backup "/etc/nginx/conf.d/$domain.d/${app}.conf"
+
+#=================================================
+# BACKUP THE PHP-FPM CONFIGURATION
+#=================================================
+
+ynh_backup "/etc/php5/fpm/pool.d/$app.conf"
+
+#=================================================
+# SPECIFIC BACKUP
+#=================================================
+# BACKUP SYSTEMD
+#=================================================
+
+ynh_backup "/etc/systemd/system/ynh-$app.service" # XXX maybe hard-coding the full name would be better
+ynh_backup "/etc/systemd/system/ynh-$app-checker.service" # XXX maybe hard-coding the full name would be better
+ynh_backup "/etc/systemd/system/ynh-$app-checker.timer" # XXX maybe hard-coding the full name would be better
 

--- a/scripts/backup
+++ b/scripts/backup
@@ -6,4 +6,3 @@ mkdir -p "${backup_dir}/"
 sudo cp -a /etc/openvpn/keys/ "${backup_dir}/"
 sudo cp -a /etc/openvpn/client.conf.tpl "${backup_dir}/"
 
-exit 0

--- a/scripts/install
+++ b/scripts/install
@@ -26,11 +26,10 @@ url_path=${2}
 
 if ! $upgrade; then
   source ./helpers
-  source ./prerequisites
 fi
 
 # Check domain/path availability
-ynh_webpath_register vpnclient $domain $url_path || exit 1
+ynh_webpath_register vpnclient $domain $url_path || ynh_die "problem on domain/path availability" 1
 
 # Install packages
 packages='php5-fpm sipcalc dnsutils openvpn curl'
@@ -150,4 +149,3 @@ fi
 
 sudo yunohost app ssowatconf
 
-exit 0

--- a/scripts/install
+++ b/scripts/install
@@ -1,60 +1,99 @@
 #!/bin/bash
 
-# VPN Client app for YunoHost 
+# VPN Client app for YunoHost
 # Copyright (C) 2015 Julien Vaubourg <julien@vaubourg.com>
 # Contribute at https://github.com/labriqueinternet/vpnclient_ynh
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# This is an upgrade?
-upgrade=$([ "${VPNCLIENT_UPGRADE}" == 1 ] && echo true || echo false)
+#=================================================
+# GENERIC START
+#=================================================
+# IMPORT GENERIC HELPERS
+#=================================================
+
+source _common.sh
+source /usr/share/yunohost/helpers
+
+#=================================================
+# MANAGE SCRIPT FAILURE
+#=================================================
+
+# Exit if an error occurs during the execution of the script
+ynh_abort_if_errors
+
+#=================================================
+# RETRIEVE ARGUMENTS FROM THE MANIFEST
+#=================================================
 
 # Retrieve arguments
-domain=${1}
-url_path=${2}
+domain=$YNH_APP_ARG_DOMAIN
+path_url=$YNH_APP_ARG_PATH
 
-if ! $upgrade; then
-  source ./helpers
-fi
+app=$YNH_APP_INSTANCE_NAME
 
-# Check domain/path availability
-ynh_webpath_register vpnclient $domain $url_path || ynh_die "problem on domain/path availability" 1
+#=================================================
+# CHECK IF THE APP CAN BE INSTALLED WITH THESE ARGS
+#=================================================
 
-# Install packages
-packages='php5-fpm sipcalc dnsutils openvpn curl fake-hwclock'
-export DEBIAN_FRONTEND=noninteractive
+# Check destination directory
+final_path="/var/www/$app"
+test ! -e "$final_path" || ynh_die "This path already contains a folder"
 
-sudo apt-get --assume-yes --force-yes install ${packages}
+# Normalize the url path syntax
+path_url=$(ynh_normalize_url_path "$path_url")
 
-if [ $? -ne 0 ]; then
-  sudo apt-get update
-  sudo apt-get --assume-yes --force-yes install ${packages}
-fi
+# Check web path availability
+ynh_webpath_available "$domain" "$path_url"
+# Register (book) web path
+ynh_webpath_register "$app" "$domain" "$path_url"
+
+#=================================================
+# STORE SETTINGS FROM MANIFEST
+#=================================================
+
+ynh_app_setting_set "$app" domain "$domain"
+ynh_app_setting_set "$app" final_path "$final_path"
+
+#=================================================
+# STANDARD MODIFICATIONS
+#=================================================
+# INSTALL DEPENDENCIES
+#=================================================
+
+ynh_install_app_dependencies "$pkg_dependencies"
+
+#=================================================
+# SPECIFIC SETUP
+#=================================================
+
+# This is an upgrade?
+upgrade=$([ -z ${VPNCLIENT_UPGRADE+x} ] && echo true || echo false)
 
 if ! $upgrade; then
 
   # Save arguments
-  sudo yunohost app setting vpnclient service_enabled -v 0
-  sudo yunohost app setting vpnclient server_name -v none
-  sudo yunohost app setting vpnclient server_port -v 1194
-  sudo yunohost app setting vpnclient server_proto -v udp
-  sudo yunohost app setting vpnclient ip6_addr -v none
-  sudo yunohost app setting vpnclient ip6_net -v none
-  sudo yunohost app setting vpnclient login_user -v "${login_user}"
-  sudo yunohost app setting vpnclient login_passphrase -v "${login_passphrase}"
-  sudo yunohost app setting vpnclient dns0 -v 89.234.141.66
-  sudo yunohost app setting vpnclient dns1 -v 2001:913::8
+  ynh_app_setting_set $app service_enabled 0
+  ynh_app_setting_set $app server_name none
+  ynh_app_setting_set $app server_port 1194
+  ynh_app_setting_set $app server_proto udp
+  ynh_app_setting_set $app ip6_addr none
+  ynh_app_setting_set $app ip6_net none
+  ynh_app_setting_set $app login_user "${login_user}"
+  ynh_app_setting_set $app login_passphrase "${login_passphrase}"
+  ynh_app_setting_set $app dns0 89.234.141.66
+  ynh_app_setting_set $app dns1 2001:913::8
 
 fi
 
@@ -90,20 +129,25 @@ sudo find /var/www/vpnadmin/ -type d -exec chmod +x {} \;
 sudo mkdir -pm 0770 /etc/openvpn/keys/
 sudo chown root:admins /etc/openvpn/keys/
 
-# Fix confs
-## nginx
-sudo sed "s|<TPL:NGINX_LOCATION>|${url_path}|g" -i "/etc/nginx/conf.d/${domain}.d/vpnadmin.conf"
+#=================================================
+# NGINX CONFIGURATION
+#=================================================
+
+sudo sed "s|<TPL:NGINX_LOCATION>|${path_url}|g" -i "/etc/nginx/conf.d/${domain}.d/vpnadmin.conf"
 sudo sed 's|<TPL:NGINX_REALPATH>|/var/www/vpnadmin/|g' -i "/etc/nginx/conf.d/${domain}.d/vpnadmin.conf"
 sudo sed 's|<TPL:PHP_NAME>|vpnadmin|g' -i "/etc/nginx/conf.d/${domain}.d/vpnadmin.conf"
 
-## php-fpm
+#=================================================
+# PHP-FPM CONFIGURATION
+#=================================================
+
 sudo sed 's|<TPL:PHP_NAME>|vpnadmin|g' -i /etc/php5/fpm/pool.d/vpnadmin.conf
 sudo sed 's|<TPL:PHP_USER>|admin|g' -i /etc/php5/fpm/pool.d/vpnadmin.conf
 sudo sed 's|<TPL:PHP_GROUP>|admins|g' -i /etc/php5/fpm/pool.d/vpnadmin.conf
 sudo sed 's|<TPL:NGINX_REALPATH>|/var/www/vpnadmin/|g' -i /etc/php5/fpm/pool.d/vpnadmin.conf
 
 # Fix sources
-sudo sed "s|<TPL:NGINX_LOCATION>|${url_path}|g" -i /var/www/vpnadmin/config.php
+sudo sed "s|<TPL:NGINX_LOCATION>|${path_url}|g" -i /var/www/vpnadmin/config.php
 
 # Copy init script
 sudo install -o root -g root -m 0755 ../conf/ynh-vpnclient /usr/local/bin/
@@ -137,11 +181,11 @@ if ! $upgrade; then
   ynh_systemctl start ynh-vpnclient
 
   # Check configuration consistency
-  
+
   if [ -z "${crt_server_ca_path}" ]; then
     echo "WARNING: VPN Client is not started because you need to define a server CA through the web admin" >&2
   fi
-  
+
   if [ -z "${crt_client_key_path}" -a -z "${login_user}" ]; then
     echo "WARNING: VPN Client is not started because you need either a client certificate, either a username (or both)" >&2
   fi

--- a/scripts/install
+++ b/scripts/install
@@ -112,18 +112,18 @@ sudo mkdir -pm 0755 /etc/yunohost/hooks.d/post_iptable_rules/
 
 sudo install -b -o root -g admins -m 0664 ../conf/openvpn_client.conf.tpl /etc/openvpn/client.conf.tpl
 sudo install -o root -g root -m 0644 ../conf/openvpn_client.conf.tpl /etc/openvpn/client.conf.tpl.restore
-sudo install -b -o root -g root -m 0644 ../conf/nginx_vpnadmin.conf "/etc/nginx/conf.d/${domain}.d/vpnadmin.conf"
-sudo install -b -o root -g root -m 0644 ../conf/phpfpm_vpnadmin.conf /etc/php5/fpm/pool.d/vpnadmin.conf
+sudo install -b -o root -g root -m 0644 ../conf/nginx_vpnadmin.conf "/etc/nginx/conf.d/${domain}.d/${app}.conf"
+sudo install -b -o root -g root -m 0644 ../conf/phpfpm_vpnadmin.conf /etc/php5/fpm/pool.d/${app}.conf
 sudo install -b -o root -g root -m 0755 ../conf/hook_post-iptable-rules /etc/yunohost/hooks.d/90-vpnclient.tpl
 sudo install -b -o root -g root -m 0644 ../conf/openvpn@.service /etc/systemd/system/
 
 # Copy web sources
-sudo mkdir -pm 0755 /var/www/vpnadmin/
-sudo cp -a ../sources/* /var/www/vpnadmin/
+sudo mkdir -pm 0755 /var/www/${app}/
+sudo cp -a ../sources/* /var/www/${app}/
 
-sudo chown -R root: /var/www/vpnadmin/
-sudo chmod -R 0644 /var/www/vpnadmin/*
-sudo find /var/www/vpnadmin/ -type d -exec chmod +x {} \;
+sudo chown -R root: /var/www/${app}/
+sudo chmod -R 0644 /var/www/${app}/*
+sudo find /var/www/${app}/ -type d -exec chmod +x {} \;
 
 # Create certificates directory
 sudo mkdir -pm 0770 /etc/openvpn/keys/
@@ -133,21 +133,21 @@ sudo chown root:admins /etc/openvpn/keys/
 # NGINX CONFIGURATION
 #=================================================
 
-sudo sed "s|<TPL:NGINX_LOCATION>|${path_url}|g" -i "/etc/nginx/conf.d/${domain}.d/vpnadmin.conf"
-sudo sed 's|<TPL:NGINX_REALPATH>|/var/www/vpnadmin/|g' -i "/etc/nginx/conf.d/${domain}.d/vpnadmin.conf"
-sudo sed 's|<TPL:PHP_NAME>|vpnadmin|g' -i "/etc/nginx/conf.d/${domain}.d/vpnadmin.conf"
+sudo sed "s|<TPL:NGINX_LOCATION>|${path_url}|g" -i "/etc/nginx/conf.d/${domain}.d/${app}.conf"
+sudo sed "s|<TPL:NGINX_REALPATH>|/var/www/${app}/|g" -i "/etc/nginx/conf.d/${domain}.d/${app}.conf"
+sudo sed "s|<TPL:PHP_NAME>|${app}|g" -i "/etc/nginx/conf.d/${domain}.d/${app}.conf"
 
 #=================================================
 # PHP-FPM CONFIGURATION
 #=================================================
 
-sudo sed 's|<TPL:PHP_NAME>|vpnadmin|g' -i /etc/php5/fpm/pool.d/vpnadmin.conf
-sudo sed 's|<TPL:PHP_USER>|admin|g' -i /etc/php5/fpm/pool.d/vpnadmin.conf
-sudo sed 's|<TPL:PHP_GROUP>|admins|g' -i /etc/php5/fpm/pool.d/vpnadmin.conf
-sudo sed 's|<TPL:NGINX_REALPATH>|/var/www/vpnadmin/|g' -i /etc/php5/fpm/pool.d/vpnadmin.conf
+sudo sed "s|<TPL:PHP_NAME>|${app}|g" -i /etc/php5/fpm/pool.d/${app}.conf
+sudo sed "s|<TPL:PHP_USER>|admin|g" -i /etc/php5/fpm/pool.d/${app}.conf
+sudo sed "s|<TPL:PHP_GROUP>|admins|g" -i /etc/php5/fpm/pool.d/${app}.conf
+sudo sed "s|<TPL:NGINX_REALPATH>|/var/www/${app}/|g" -i /etc/php5/fpm/pool.d/${app}.conf
 
 # Fix sources
-sudo sed "s|<TPL:NGINX_LOCATION>|${path_url}|g" -i /var/www/vpnadmin/config.php
+sudo sed "s|<TPL:NGINX_LOCATION>|${path_url}|g" -i /var/www/${app}/config.php
 
 # Copy init script
 sudo install -o root -g root -m 0755 ../conf/ynh-vpnclient /usr/local/bin/

--- a/scripts/install
+++ b/scripts/install
@@ -32,7 +32,7 @@ fi
 ynh_webpath_register vpnclient $domain $url_path || ynh_die "problem on domain/path availability" 1
 
 # Install packages
-packages='php5-fpm sipcalc dnsutils openvpn curl'
+packages='php5-fpm sipcalc dnsutils openvpn curl fake-hwclock'
 export DEBIAN_FRONTEND=noninteractive
 
 sudo apt-get --assume-yes --force-yes install ${packages}

--- a/scripts/prerequisites
+++ b/scripts/prerequisites
@@ -1,8 +1,0 @@
-# Source me
-
-# Check YunoHost version (firewall hook in Moulinette)
-ynh_version=$(sudo dpkg -l yunohost | grep ii | awk '{ print $3 }' | sed 's/\.//g')
-
-if [ "${ynh_version}" -lt 240 ]; then
-  echo "WARN: You need a YunoHost's version equals or greater than 2.4.0 for activating the firewalling" >&2
-fi

--- a/scripts/remove
+++ b/scripts/remove
@@ -48,8 +48,8 @@ sudo rm -f /tmp/.ynh-vpnclient-*
 
 # Remove confs
 sudo rm -f /etc/openvpn/client.conf{.tpl,.tpl.restore,}
-sudo rm -f /etc/nginx/conf.d/${domain}.d/vpnadmin.conf
-sudo rm -f /etc/php5/fpm/pool.d/vpnadmin.conf
+sudo rm -f /etc/nginx/conf.d/${domain}.d/${app}.conf
+sudo rm -f /etc/php5/fpm/pool.d/${app}.conf
 sudo rm -f /etc/yunohost/hooks.d/90-vpnclient.tpl
 sudo rm -f /etc/systemd/system/openvpn@.service
 
@@ -61,5 +61,5 @@ sudo systemctl restart php5-fpm
 sudo systemctl reload nginx
 
 # Remove sources
-sudo rm -rf /var/www/vpnadmin/
+sudo rm -rf /var/www/${app}/
 

--- a/scripts/remove
+++ b/scripts/remove
@@ -50,4 +50,3 @@ sudo systemctl reload nginx
 # Remove sources
 sudo rm -rf /var/www/vpnadmin/
 
-exit 0

--- a/scripts/remove
+++ b/scripts/remove
@@ -1,27 +1,40 @@
 #!/bin/bash
 
-# VPN Client app for YunoHost 
+# VPN Client app for YunoHost
 # Copyright (C) 2015 Julien Vaubourg <julien@vaubourg.com>
 # Contribute at https://github.com/labriqueinternet/vpnclient_ynh
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-source ./helpers
+#=================================================
+# GENERIC STARTING
+#=================================================
+# IMPORT GENERIC HELPERS
+#=================================================
 
-# Retrieve arguments
-domain=$(sudo yunohost app setting vpnclient domain)
+source _common.sh
+source /usr/share/yunohost/helpers
 
+#=================================================
+# LOAD SETTINGS
+#=================================================
+
+app=$YNH_APP_INSTANCE_NAME
+
+domain=$(ynh_app_setting_get $app domain)
+
+#=================================================
 # The End
 ynh_systemctl stop ynh-vpnclient-checker.service
 sudo systemctl disable ynh-vpnclient-checker.service

--- a/scripts/restore
+++ b/scripts/restore
@@ -1,5 +1,24 @@
 #!/bin/bash
 
+#=================================================
+# IMPORT GENERIC HELPERS
+#=================================================
+
+if [ ! -e _common.sh ]; then
+    # Fetch helpers file if not in current directory
+    cp ../settings/scripts/_common.sh ./_common.sh
+    chmod a+rx _common.sh
+fi
+source _common.sh
+source /usr/share/yunohost/helpers
+
+#=================================================
+# MANAGE SCRIPT FAILURE
+#=================================================
+
+# Exit if an error occurs during the execution of the script
+ynh_abort_if_errors
+
 backup_dir="${1}/apps/vpnclient"
 
 sudo mkdir -p /etc/openvpn/

--- a/scripts/restore
+++ b/scripts/restore
@@ -18,4 +18,3 @@ bash ./upgrade
 
 sudo rm -r "${tmpdir}/"
 
-exit 0

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -8,7 +8,6 @@ ynh_setting() {
 }
 
 source ./helpers
-source ./prerequisites
 
 domain=$(ynh_setting vpnclient domain)
 path=$(ynh_setting vpnclient path)
@@ -44,4 +43,3 @@ fi
 
 ynh_systemctl start ynh-vpnclient
 
-exit 0

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -22,6 +22,23 @@ final_path=$(ynh_app_setting_get $app final_path)
 server_name=$(ynh_app_setting_get $app server_name)
 
 #=================================================
+# SPECIAL UPGRADE FOR VERSIONS < 1.2.0
+#=================================================
+
+# Apply renaming that occured in v1.2.0 ("vpnadmin" -> "${app}")
+if [ -f /etc/nginx/conf.d/${domain}.d/vpnadmin.conf ]; then
+  sudo sed "s|/var/www/vpnadmin/|/var/www/${app}/|g" -i "/etc/nginx/conf.d/${domain}.d/vpnadmin.conf"
+  sudo sed "s|vpnadmin.sock|${app}.sock|g" -i "/etc/nginx/conf.d/${domain}.d/vpnadmin.conf"
+  mv /etc/nginx/conf.d/${domain}.d/vpnadmin.conf /etc/nginx/conf.d/${domain}.d/${app}.conf
+fi
+if [ -f /etc/php5/fpm/pool.d/vpnadmin.conf ]; then
+  sudo sed "s|/var/www/vpnadmin/|/var/www/${app}/|g" -i /etc/php5/fpm/pool.d/vpnadmin.conf
+  sudo sed "s|vpnadmin.sock|${app}.sock|g" -i  /etc/php5/fpm/pool.d/vpnadmin.conf
+  mv /etc/php5/fpm/pool.d/vpnadmin.conf /etc/php5/fpm/pool.d/${app}.conf
+fi
+test -d /var/www/vpnadmin && mv /var/www/vpnadmin /var/www/${app}
+
+#=================================================
 # BACKUP BEFORE UPGRADE THEN ACTIVE TRAP
 #=================================================
 
@@ -32,3 +49,9 @@ ynh_clean_setup () {
 # Exit if an error occurs during the execution of the script
 ynh_abort_if_errors
 
+#=================================================
+# RELOAD RELEVANT SERVICES
+#=================================================
+
+ynh_systemctl reload php5-fpm
+ynh_systemctl reload nginx

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -10,13 +10,6 @@ source _common.sh
 source /usr/share/yunohost/helpers
 
 #=================================================
-# MANAGE SCRIPT FAILURE
-#=================================================
-
-# Exit if an error occurs during the execution of the script
-ynh_abort_if_errors
-
-#=================================================
 # LOAD SETTINGS
 #=================================================
 
@@ -29,41 +22,13 @@ final_path=$(ynh_app_setting_get $app final_path)
 server_name=$(ynh_app_setting_get $app server_name)
 
 #=================================================
-# CHECK VERSION
+# BACKUP BEFORE UPGRADE THEN ACTIVE TRAP
 #=================================================
 
-ynh_abort_if_up_to_date
-
-#=================================================
-
-
-sudo mkdir -m 0700 -p /var/cache/labriqueinternet/vpnclient/
-sudo tar czf "/var/cache/labriqueinternet/vpnclient/rollback_$(date +%Y-%m-%d-%H%M%S).tgz" /etc/openvpn/ /etc/yunohost/apps/vpnclient/ &> /dev/null
-
-tmpdir=$(mktemp -dp /tmp/ vpnclient-upgrade-XXXXX)
-sudo cp -a /etc/yunohost/apps/vpnclient/settings.yml "${tmpdir}/"
-sudo cp -a /etc/openvpn/keys/ "${tmpdir}/"
-
-if [ ! -e /etc/openvpn/client.conf.tpl.restore ] || ! cmp -s /etc/openvpn/client.conf.tpl{,.restore}; then
-  sudo cp -a /etc/openvpn/client.conf.tpl "${tmpdir}/"
-fi
-
-export VPNCLIENT_UPGRADE=1
-sudo bash /etc/yunohost/apps/vpnclient/scripts/remove &> /dev/null
-bash ./install "${domain}" "${path}" "${server_name}"
-
-sudo rmdir /etc/openvpn/keys/
-sudo cp -a "${tmpdir}/keys/" /etc/openvpn/keys/
-sudo cp -a "${tmpdir}/settings.yml" /etc/yunohost/apps/vpnclient/
-sudo cp -a "${tmpdir}/client.conf.tpl" /etc/openvpn/ 2> /dev/null
-sudo rm -r "${tmpdir}/"
-
-# Changes
-
-if [ -z "$(ynh_setting vpnclient dns0)" ]; then
-  sudo yunohost app setting vpnclient dns0 -v 89.234.141.66
-  sudo yunohost app setting vpnclient dns1 -v 2001:913::8
-fi
-
-ynh_systemctl start ynh-vpnclient
+ynh_backup_before_upgrade
+ynh_clean_setup () {
+    ynh_restore_upgradebackup
+}
+# Exit if an error occurs during the execution of the script
+ynh_abort_if_errors
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -38,6 +38,13 @@ if [ -f /etc/php5/fpm/pool.d/vpnadmin.conf ]; then
 fi
 test -d /var/www/vpnadmin && mv /var/www/vpnadmin /var/www/${app}
 
+# Versions known to have a buggy backup script
+buggy_versions="1.0.0 1.0.1 1.1.0"
+curr_version=$(read_manifest version)
+if echo $buggy_versions | grep -w $curr_version > /dev/null; then
+  echo "Your current version of ${app} is very old: ${curr_version}. Please ignore the next warning." >&2
+fi
+
 #=================================================
 # BACKUP BEFORE UPGRADE THEN ACTIVE TRAP
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -3,8 +3,7 @@
 ynh_setting() {
   app=${1}
   setting=${2}
-
-  sudo grep "^${setting}:" "/etc/yunohost/apps/${app}/settings.yml" | sed s/^[^:]\\+:\\s*[\"\']\\?// | sed s/\\s*[\"\']\$//
+  ynh_app_setting_get $app $setting
 }
 
 source ./helpers

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -1,16 +1,41 @@
 #!/bin/bash
 
-ynh_setting() {
-  app=${1}
-  setting=${2}
-  ynh_app_setting_get $app $setting
-}
+#=================================================
+# GENERIC STARTING
+#=================================================
+# IMPORT GENERIC HELPERS
+#=================================================
 
-source ./helpers
+source _common.sh
+source /usr/share/yunohost/helpers
 
-domain=$(ynh_setting vpnclient domain)
-path=$(ynh_setting vpnclient path)
-server_name=$(ynh_setting vpnclient server_name)
+#=================================================
+# MANAGE SCRIPT FAILURE
+#=================================================
+
+# Exit if an error occurs during the execution of the script
+ynh_abort_if_errors
+
+#=================================================
+# LOAD SETTINGS
+#=================================================
+
+app=$YNH_APP_INSTANCE_NAME
+
+domain=$(ynh_app_setting_get $app domain)
+path_url=$(ynh_app_setting_get $app path)
+is_public=$(ynh_app_setting_get $app is_public)
+final_path=$(ynh_app_setting_get $app final_path)
+server_name=$(ynh_app_setting_get $app server_name)
+
+#=================================================
+# CHECK VERSION
+#=================================================
+
+ynh_abort_if_up_to_date
+
+#=================================================
+
 
 sudo mkdir -m 0700 -p /var/cache/labriqueinternet/vpnclient/
 sudo tar czf "/var/cache/labriqueinternet/vpnclient/rollback_$(date +%Y-%m-%d-%H%M%S).tgz" /etc/openvpn/ /etc/yunohost/apps/vpnclient/ &> /dev/null


### PR DESCRIPTION
## The problem

The upgrade script is currently broken. It invokes `remove` and `install` scripts which is not working anymore.
It probably never really worked I guess, but now it's obvious thanks to the call to `ynh_abort_if_errors` introduced recently.

## The solution
It's time to rewrite all the scripts.

This PR only cares about the `upgrade` script for now.
I tried to follow yunohost guidelines by taking inspiration from the app [example_ynh](https://github.com/YunoHost/example_ynh/).

You can test it on a live cube like this: `yunohost app upgrade vpnclient -u https://github.com/pitchum/vpnclient_ynh/`