### PR TITLE
A fix for the fix in PR #37

### DIFF
--- a/conf/ynh-vpnclient
+++ b/conf/ynh-vpnclient
@@ -205,12 +205,12 @@ sync_time() {
   # Try to get the date with an http request on the internetcube web site
   if [ $? -ne 0 ]; then
     http_date=`curl -sD - labriqueinter.net | grep '^Date:' | cut -d' ' -f3-6`
-    http_date=`date -d "${http_date}" +%s`
-    current_date=`date +%s`
+    http_date_seconds=`date -d "${http_date}" +%s`
+    curr_date_seconds=`date +%s`
 
     # Set the new date if it's greater than the current date
     # So it does if 1970 year or if old fake-hwclock date is used
-    if [ $http_date -ge $current_date ]; then
+    if [ $http_date_seconds -ge $curr_date_seconds ]; then
       date -s "${http_date}"
     fi
   fi 


### PR DESCRIPTION
# The problem
The fix proposed in PR #37 is broken.
`date -s "${http_date}"` won't work if *${http_date}* is expressed in seconds.

# The solution

store *http_date* in two separate variables.