### PR TITLE
Fix upgrade maybe :<

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -24,13 +24,13 @@ upgrade=$([ "${VPNCLIENT_UPGRADE}" == 1 ] && echo true || echo false)
 domain=${1}
 url_path=${2}
 
-if ! $upgrade; then
-  source ./helpers
-  source ./prerequisites
-fi
+source ./helpers
+source ./prerequisites
 
 # Check domain/path availability
-ynh_webpath_register vpnclient $domain $url_path || exit 1
+if ! $upgrade; then
+   ynh_webpath_register vpnclient $domain $url_path || exit 1
+fi
 
 # Install packages
 packages='php5-fpm sipcalc dnsutils openvpn curl fake-hwclock'


### PR DESCRIPTION
One or two weeks ago we had an issue when trying to upgrade vpnclient ... Turns out the error was caused by the upgrade script calling the install script, which does not source helpers if the upgrade is being ran ... But that doesn't make sense because the next thing being done is calling `ynh_webpath_register` which is an helper.

In fact, what should *not* be done is running `ynh_webpath_register` during the upgrade as the path i already registered

(I dunno how this compares to pitchum's more extensive work on the topic, maybe this PR isnt relevant or less relevant than his ;P)