### PR TITLE
No need to 'sudo' all over the place

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -33,7 +33,7 @@ to_logs() {
 # Experimental helpers
 # Cf. https://github.com/YunoHost-Apps/Experimental_helpers/blob/72b0bc77c68d4a4a2bf4e95663dbc05e4a762a0a/ynh_read_manifest/ynh_read_manifest
 read_json () {
-    sudo python3 -c "import sys, json;print(json.load(open('$1'))['$2'])"
+    python3 -c "import sys, json;print(json.load(open('$1'))['$2'])"
 }
 
 # Experimental helper
@@ -72,7 +72,7 @@ function ynh_systemctl()
   local LOCKFILE="/var/run/moulinette_yunohost.lock"
 
   # Launch the action
-  sudo systemctl "$ACTION" "$SERVICE" &
+  systemctl "$ACTION" "$SERVICE" &
   local SYSCTLACTION=$!
 
   # Save and release the lock...
@@ -142,7 +142,7 @@ ynh_app_package_version () {
 #
 # To force an upgrade, even if the package is up to date,
 # you have to set the variable YNH_FORCE_UPGRADE before.
-# example: sudo YNH_FORCE_UPGRADE=1 yunohost app upgrade MyApp
+# example: YNH_FORCE_UPGRADE=1 yunohost app upgrade MyApp
 #
 # usage: ynh_abort_if_up_to_date
 ynh_abort_if_up_to_date () {
@@ -179,70 +179,70 @@ function vpnclient_deploy_files_and_services()
     ynh_system_user_create ${sysuser}
   fi
 
-  # Ensure the system user has enough sudo permissions
-  sudo install -b -o root -g root -m 0440 ../conf/sudoers.conf /etc/sudoers.d/${app}_ynh
+  # Ensure the system user has enough permissions
+  install -b -o root -g root -m 0440 ../conf/sudoers.conf /etc/sudoers.d/${app}_ynh
   ynh_replace_string "__VPNCLIENT_SYSUSER__" "${sysuser}" /etc/sudoers.d/${app}_ynh
 
   # Install IPv6 scripts
-  sudo install -o root -g root -m 0755 ../conf/ipv6_expanded /usr/local/bin/
-  sudo install -o root -g root -m 0755 ../conf/ipv6_compressed /usr/local/bin/
+  install -o root -g root -m 0755 ../conf/ipv6_expanded /usr/local/bin/
+  install -o root -g root -m 0755 ../conf/ipv6_compressed /usr/local/bin/
 
   # Install command-line cube file loader
-  sudo install -o root -g root -m 0755 ../conf/ynh-vpnclient-loadcubefile.sh /usr/local/bin/
+  install -o root -g root -m 0755 ../conf/ynh-vpnclient-loadcubefile.sh /usr/local/bin/
 
   # Copy confs
-  sudo mkdir -pm 0755 /var/log/nginx/
-  sudo chown root:${sysuser} /etc/openvpn/
-  sudo chmod 775 /etc/openvpn/
-  sudo mkdir -pm 0755 /etc/yunohost/hooks.d/post_iptable_rules/
+  mkdir -pm 0755 /var/log/nginx/
+  chown root:${sysuser} /etc/openvpn/
+  chmod 775 /etc/openvpn/
+  mkdir -pm 0755 /etc/yunohost/hooks.d/post_iptable_rules/
 
-  sudo install -b -o root -g ${sysuser} -m 0664 ../conf/openvpn_client.conf.tpl /etc/openvpn/client.conf.tpl
-  sudo install -o root -g root -m 0644 ../conf/openvpn_client.conf.tpl /etc/openvpn/client.conf.tpl.restore
-  sudo install -b -o root -g root -m 0644 ../conf/nginx_vpnadmin.conf "/etc/nginx/conf.d/${domain}.d/${app}.conf"
-  sudo install -b -o root -g root -m 0644 ../conf/phpfpm_vpnadmin.conf /etc/php5/fpm/pool.d/${app}.conf
-  sudo install -b -o root -g root -m 0755 ../conf/hook_post-iptable-rules /etc/yunohost/hooks.d/90-vpnclient.tpl
-  sudo install -b -o root -g root -m 0644 ../conf/openvpn@.service /etc/systemd/system/
+  install -b -o root -g ${sysuser} -m 0664 ../conf/openvpn_client.conf.tpl /etc/openvpn/client.conf.tpl
+  install -o root -g root -m 0644 ../conf/openvpn_client.conf.tpl /etc/openvpn/client.conf.tpl.restore
+  install -b -o root -g root -m 0644 ../conf/nginx_vpnadmin.conf "/etc/nginx/conf.d/${domain}.d/${app}.conf"
+  install -b -o root -g root -m 0644 ../conf/phpfpm_vpnadmin.conf /etc/php5/fpm/pool.d/${app}.conf
+  install -b -o root -g root -m 0755 ../conf/hook_post-iptable-rules /etc/yunohost/hooks.d/90-vpnclient.tpl
+  install -b -o root -g root -m 0644 ../conf/openvpn@.service /etc/systemd/system/
 
   # Copy web sources
-  sudo mkdir -pm 0755 /var/www/${app}/
-  sudo cp -a ../sources/* /var/www/${app}/
+  mkdir -pm 0755 /var/www/${app}/
+  cp -a ../sources/* /var/www/${app}/
 
-  sudo chown -R root: /var/www/${app}/
-  sudo chmod -R 0644 /var/www/${app}/*
-  sudo find /var/www/${app}/ -type d -exec chmod +x {} \;
+  chown -R root: /var/www/${app}/
+  chmod -R 0644 /var/www/${app}/*
+  find /var/www/${app}/ -type d -exec chmod +x {} \;
 
   # Create certificates directory
-  sudo mkdir -pm 0770 /etc/openvpn/keys/
-  sudo chown root:${sysuser} /etc/openvpn/keys/
+  mkdir -pm 0770 /etc/openvpn/keys/
+  chown root:${sysuser} /etc/openvpn/keys/
 
   #=================================================
   # NGINX CONFIGURATION
   #=================================================
 
-  sudo sed "s|<TPL:NGINX_LOCATION>|${path_url}|g" -i "/etc/nginx/conf.d/${domain}.d/${app}.conf"
-  sudo sed "s|<TPL:NGINX_REALPATH>|/var/www/${app}/|g" -i "/etc/nginx/conf.d/${domain}.d/${app}.conf"
-  sudo sed "s|<TPL:PHP_NAME>|${app}|g" -i "/etc/nginx/conf.d/${domain}.d/${app}.conf"
+  sed "s|<TPL:NGINX_LOCATION>|${path_url}|g" -i "/etc/nginx/conf.d/${domain}.d/${app}.conf"
+  sed "s|<TPL:NGINX_REALPATH>|/var/www/${app}/|g" -i "/etc/nginx/conf.d/${domain}.d/${app}.conf"
+  sed "s|<TPL:PHP_NAME>|${app}|g" -i "/etc/nginx/conf.d/${domain}.d/${app}.conf"
 
   #=================================================
   # PHP-FPM CONFIGURATION
   #=================================================
 
-  sudo sed "s|<TPL:PHP_NAME>|${app}|g" -i /etc/php5/fpm/pool.d/${app}.conf
-  sudo sed "s|<TPL:PHP_USER>|${sysuser}|g" -i /etc/php5/fpm/pool.d/${app}.conf
-  sudo sed "s|<TPL:PHP_GROUP>|${sysuser}|g" -i /etc/php5/fpm/pool.d/${app}.conf
-  sudo sed "s|<TPL:NGINX_REALPATH>|/var/www/${app}/|g" -i /etc/php5/fpm/pool.d/${app}.conf
+  sed "s|<TPL:PHP_NAME>|${app}|g" -i /etc/php5/fpm/pool.d/${app}.conf
+  sed "s|<TPL:PHP_USER>|${sysuser}|g" -i /etc/php5/fpm/pool.d/${app}.conf
+  sed "s|<TPL:PHP_GROUP>|${sysuser}|g" -i /etc/php5/fpm/pool.d/${app}.conf
+  sed "s|<TPL:NGINX_REALPATH>|/var/www/${app}/|g" -i /etc/php5/fpm/pool.d/${app}.conf
 
   # Fix sources
-  sudo sed "s|<TPL:NGINX_LOCATION>|${path_url}|g" -i /var/www/${app}/config.php
+  sed "s|<TPL:NGINX_LOCATION>|${path_url}|g" -i /var/www/${app}/config.php
 
   # Copy init script
-  sudo install -o root -g root -m 0755 ../conf/ynh-vpnclient /usr/local/bin/
-  sudo install -o root -g root -m 0644 ../conf/ynh-vpnclient.service /etc/systemd/system/
+  install -o root -g root -m 0755 ../conf/ynh-vpnclient /usr/local/bin/
+  install -o root -g root -m 0644 ../conf/ynh-vpnclient.service /etc/systemd/system/
 
   # Copy checker timer
-  sudo install -o root -g root -m 0755 ../conf/ynh-vpnclient-checker.sh /usr/local/bin/
-  sudo install -o root -g root -m 0644 ../conf/ynh-vpnclient-checker.service /etc/systemd/system/
-  sudo install -o root -g root -m 0644 ../conf/ynh-vpnclient-checker.timer /etc/systemd/system/
+  install -o root -g root -m 0755 ../conf/ynh-vpnclient-checker.sh /usr/local/bin/
+  install -o root -g root -m 0644 ../conf/ynh-vpnclient-checker.service /etc/systemd/system/
+  install -o root -g root -m 0644 ../conf/ynh-vpnclient-checker.timer /etc/systemd/system/
 
-  sudo systemctl daemon-reload
+  systemctl daemon-reload
 }

--- a/scripts/helpers
+++ b/scripts/helpers
@@ -18,7 +18,7 @@ function ynh_systemctl()
   local LOCKFILE="/var/run/moulinette_yunohost.lock"
 
   # Launch the action
-  sudo systemctl "$ACTION" "$SERVICE" &
+  systemctl "$ACTION" "$SERVICE" &
   local SYSCTLACTION=$!
 
   # Save and release the lock...

--- a/scripts/install
+++ b/scripts/install
@@ -86,21 +86,21 @@ ynh_app_setting_set $app final_path $final_path
 # Set default inits
 # The boot order of these services are important, so they are disabled by default
 # and the ynh-vpnclient service handles them.
-sudo systemctl disable openvpn
-sudo systemctl stop openvpn
+systemctl disable openvpn
+systemctl stop openvpn
 
-sudo systemctl enable php5-fpm
-sudo systemctl restart php5-fpm
+systemctl enable php5-fpm
+systemctl restart php5-fpm
 
-sudo systemctl reload nginx
+systemctl reload nginx
 
-sudo systemctl enable ynh-vpnclient
-sudo yunohost service add ynh-vpnclient
+systemctl enable ynh-vpnclient
+yunohost service add ynh-vpnclient
 
 ynh_systemctl start ynh-vpnclient-checker.service
-sudo systemctl enable ynh-vpnclient-checker.service
+systemctl enable ynh-vpnclient-checker.service
 ynh_systemctl start ynh-vpnclient-checker.timer
-sudo systemctl enable ynh-vpnclient-checker.timer
+systemctl enable ynh-vpnclient-checker.timer
 
 
-sudo yunohost app ssowatconf
+yunohost app ssowatconf

--- a/scripts/prerequisites
+++ b/scripts/prerequisites
@@ -1,7 +1,7 @@
 # Source me
 
 # Check YunoHost version (firewall hook in Moulinette)
-ynh_version=$(sudo dpkg -l yunohost | grep ii | awk '{ print $3 }' | sed 's/\.//g')
+ynh_version=$(dpkg -l yunohost | grep ii | awk '{ print $3 }' | sed 's/\.//g')
 
 if [ "${ynh_version}" -lt 240 ]; then
   echo "WARN: You need a YunoHost's version equals or greater than 2.4.0 for activating the firewalling" >&2

--- a/scripts/remove
+++ b/scripts/remove
@@ -37,35 +37,35 @@ domain=$(ynh_app_setting_get $app domain)
 #=================================================
 # The End
 ynh_systemctl stop ynh-vpnclient-checker.service
-sudo systemctl disable ynh-vpnclient-checker.service
+systemctl disable ynh-vpnclient-checker.service
 ynh_systemctl stop ynh-vpnclient-checker.timer && sleep 1
-sudo systemctl disable ynh-vpnclient-checker.timer
+systemctl disable ynh-vpnclient-checker.timer
 ynh_systemctl stop ynh-vpnclient
-sudo systemctl disable ynh-vpnclient
-sudo yunohost service remove ynh-vpnclient
-sudo rm -f /etc/systemd/system/ynh-vpnclient* /usr/local/bin/ynh-vpnclient*
-sudo rm -f /tmp/.ynh-vpnclient-*
+systemctl disable ynh-vpnclient
+yunohost service remove ynh-vpnclient
+rm -f /etc/systemd/system/ynh-vpnclient* /usr/local/bin/ynh-vpnclient*
+rm -f /tmp/.ynh-vpnclient-*
 
 # Remove confs
-sudo rm -f /etc/openvpn/client.conf{.tpl,.tpl.restore,}
-sudo rm -f /etc/nginx/conf.d/${domain}.d/${app}.conf
-sudo rm -f /etc/php5/fpm/pool.d/${app}.conf
-sudo rm -f /etc/yunohost/hooks.d/90-vpnclient.tpl
-sudo rm -f /etc/systemd/system/openvpn@.service
+rm -f /etc/openvpn/client.conf{.tpl,.tpl.restore,}
+rm -f /etc/nginx/conf.d/${domain}.d/${app}.conf
+rm -f /etc/php5/fpm/pool.d/${app}.conf
+rm -f /etc/yunohost/hooks.d/90-vpnclient.tpl
+rm -f /etc/systemd/system/openvpn@.service
 
 # Remove certificates
-sudo rm -rf /etc/openvpn/keys/
+rm -rf /etc/openvpn/keys/
 
 # Remove packages
 ynh_remove_app_dependencies
 
 # Restart services
-sudo systemctl restart php5-fpm
-sudo systemctl reload nginx
+systemctl restart php5-fpm
+systemctl reload nginx
 
 # Remove sources
-sudo rm -rf /var/www/${app}/
+rm -rf /var/www/${app}/
 
 # Removed system user
 ynh_system_user_delete ${app}
-sudo rm -f /etc/sudoers.d/${app}_ynh
+rm -f /etc/sudoers.d/${app}_ynh

--- a/scripts/restore
+++ b/scripts/restore
@@ -26,12 +26,12 @@ sysuser="vpnclient" # XXX hard-coded variable
 
 backup_dir="${1}/apps/vpnclient"
 
-sudo mkdir -p /etc/openvpn/
-sudo cp -a "${backup_dir}/keys/" /etc/openvpn/
-sudo cp -a "${backup_dir}/client.conf.tpl" /etc/openvpn/
-sudo chown -R root:${sysuser} /etc/openvpn/keys/
+mkdir -p /etc/openvpn/
+cp -a "${backup_dir}/keys/" /etc/openvpn/
+cp -a "${backup_dir}/client.conf.tpl" /etc/openvpn/
+chown -R root:${sysuser} /etc/openvpn/keys/
 
-gitcommit=$(sudo grep revision /etc/yunohost/apps/vpnclient/status.json | sed 's/.*"revision": "\([^"]\+\)".*/\1/')
+gitcommit=$(grep revision /etc/yunohost/apps/vpnclient/status.json | sed 's/.*"revision": "\([^"]\+\)".*/\1/')
 tmpdir=$(mktemp -dp /tmp/ vpnclient-restore-XXXXX)
 
 git clone https://github.com/labriqueinternet/vpnclient_ynh.git "${tmpdir}/"
@@ -40,4 +40,4 @@ git --work-tree "${tmpdir}/" --git-dir "${tmpdir}/.git/" reset --hard "${gitcomm
 cd "${tmpdir}/scripts/"
 bash ./upgrade 
 
-sudo rm -r "${tmpdir}/"
+rm -r "${tmpdir}/"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -27,13 +27,13 @@ server_name=$(ynh_app_setting_get $app server_name)
 
 # Apply renaming that occured in v1.2.0 ("vpnadmin" -> "${app}")
 if [ -f /etc/nginx/conf.d/${domain}.d/vpnadmin.conf ]; then
-  sudo sed "s|/var/www/vpnadmin/|/var/www/${app}/|g" -i "/etc/nginx/conf.d/${domain}.d/vpnadmin.conf"
-  sudo sed "s|vpnadmin.sock|${app}.sock|g" -i "/etc/nginx/conf.d/${domain}.d/vpnadmin.conf"
+  sed "s|/var/www/vpnadmin/|/var/www/${app}/|g" -i "/etc/nginx/conf.d/${domain}.d/vpnadmin.conf"
+  sed "s|vpnadmin.sock|${app}.sock|g" -i "/etc/nginx/conf.d/${domain}.d/vpnadmin.conf"
   mv /etc/nginx/conf.d/${domain}.d/vpnadmin.conf /etc/nginx/conf.d/${domain}.d/${app}.conf
 fi
 if [ -f /etc/php5/fpm/pool.d/vpnadmin.conf ]; then
-  sudo sed "s|/var/www/vpnadmin/|/var/www/${app}/|g" -i /etc/php5/fpm/pool.d/vpnadmin.conf
-  sudo sed "s|vpnadmin.sock|${app}.sock|g" -i  /etc/php5/fpm/pool.d/vpnadmin.conf
+  sed "s|/var/www/vpnadmin/|/var/www/${app}/|g" -i /etc/php5/fpm/pool.d/vpnadmin.conf
+  sed "s|vpnadmin.sock|${app}.sock|g" -i  /etc/php5/fpm/pool.d/vpnadmin.conf
   mv /etc/php5/fpm/pool.d/vpnadmin.conf /etc/php5/fpm/pool.d/${app}.conf
 fi
 test -d /var/www/vpnadmin && mv /var/www/vpnadmin /var/www/${app}
@@ -70,14 +70,14 @@ ynh_install_app_dependencies "$pkg_dependencies"
 
 # Keep a copy of existing config files before overwriting them
 tmpdir=$(mktemp -d /tmp/vpnclient-upgrade-XXX)
-sudo cp -r /etc/openvpn/client* ${tmpdir}
+cp -r /etc/openvpn/client* ${tmpdir}
 
 # Deploy files from package
 vpnclient_deploy_files_and_services "${domain}" "${app}"
 
 # Restore previously existing config files
-sudo cp -r ${tmpdir}/client* /etc/openvpn/
-sudo rm -rf ${tmpdir}
+cp -r ${tmpdir}/client* /etc/openvpn/
+rm -rf ${tmpdir}
 
 #=================================================
 # RELOAD RELEVANT SERVICES


### PR DESCRIPTION
Historically scripts were run as 'admin' but nowadays they are run as 'root' and there's no need to put sudo everywhere.

I removed sudo in all files in `scripts/` as i'm not 100% sure about others files in conf which might be ran as root