### PR TITLE
Change for a best way of verifying if authentication is successful 

### DIFF
--- a/conf/ynh-vpnclient-loadcubefile.sh
+++ b/conf/ynh-vpnclient-loadcubefile.sh
@@ -86,7 +86,7 @@ ynh_service_enabled=$(ynh_setting vpnclient service_enabled)
 
 # SSO login
 
-curl -kLe "https://${ynh_domain}/yunohost/sso/" --data-urlencode "user=${ynh_user}" --data-urlencode "password=${ynh_password}" "https://${ynh_domain}/yunohost/sso/" --resolve "${ynh_domain}:443:127.0.0.1" -c "${tmpdir}/cookies" 2> /dev/null | grep -q Logout
+curl -D - -skLe "https://${ynh_domain}/yunohost/sso/" --data-urlencode "user=${ynh_user}" --data-urlencode "password=${ynh_password}" "https://${ynh_domain}/yunohost/sso/" --resolve "${ynh_domain}:443:127.0.0.1" -o /dev/null -c "${tmpdir}/cookies" 2> /dev/null | grep -q "set-cookie: SSOwAuthUser=${ynh_user}"
 
 if [ $? -ne 0 ]; then
   echo "[ERROR] SSO login failed" >&2


### PR DESCRIPTION
This change checks if a http header is set instead of looking into web page content.

Fix #60 

It has been tested on a cube (lime2) with a full installation.