### PR TITLE
Allow bonjour protocol

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,9 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleasead
 
+## 1.4.1~ynh1 - 2020-05-11
+
+- [fix] app cannot be deployed as main app
+
+
 ## 1.4.1 - 2020-04-04
 
 - [fix] ynh-vpnclient-loadcubefile.sh broken with ssowat 3.7.x (#60)
+
 
 ## 1.4.0 - 2019-03-18
 

--- a/conf/hook_post-iptable-rules
+++ b/conf/hook_post-iptable-rules
@@ -29,6 +29,7 @@ for i in <TPL:DNS0> <TPL:DNS1>; do
 done
 
 sudo ip6tables -w -A vpnclient_out -d fd00::/8,fe80::/10 -j ACCEPT
+sudo ip6tables -w -A vpnclient_out -p udp --dport 5353 -d ff02::fb -j ACCEPT
 sudo ip6tables -w -A vpnclient_out -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 sudo ip6tables -w -A vpnclient_out -j DROP
 
@@ -64,6 +65,7 @@ for i in <TPL:DNS0> <TPL:DNS1>; do
 done
 
 sudo iptables -w -A vpnclient_out -d 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.0.0/16 -j ACCEPT
+sudo iptables -w -A vpnclient_out -p udp --dport 5353 -d 224.0.0.251 -j ACCEPT
 sudo iptables -w -A vpnclient_out -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 sudo iptables -w -A vpnclient_out -j DROP
 


### PR DESCRIPTION
Realized today with @zamentur that the current firewall rules are blocking bonjour protocol when vpnclient is up ...

As a "reminder" this is related to the use of `yunohost.local` (or any `.local` declared by the server using avahi daemon)

The reason is that the protocol uses multicast packets which (as far as we understood) does not appear to be coming from e.g. 10.0.0.0/8 or 192.168.0.0/16 - therefore doesn't match the existing rules

(This is related to the current work on improving Yunohost / InternetCube installation procedure, e.g. reaching internetcube.local and/or briqueinternet.local to connect to the install interface - or later the admin interface)

"References" : 

- https://en.wikipedia.org/wiki/Bonjour_(software)
- https://en.wikipedia.org/wiki/.local
- https://en.wikipedia.org/wiki/Multicast_DNS