### PR TITLE
Dont integrate vpnclient checker

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,9 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleasead
 
+## 1.4.1~ynh1 - 2020-05-11
+
+- [fix] app cannot be deployed as main app
+
+
 ## 1.4.1 - 2020-04-04
 
 - [fix] ynh-vpnclient-loadcubefile.sh broken with ssowat 3.7.x (#60)
+
 
 ## 1.4.0 - 2019-03-18
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "VPN Client",
   "id": "vpnclient",
   "packaging_format": 1,
-  "version": "1.4.1~ynh1",
+  "version": "1.4.1~ynh2",
   "description": {
     "en": "Tunnel the internet traffic through a VPN",
     "fr": "Fais passer le traffic internet à travers un VPN"
@@ -15,7 +15,7 @@
   },
   "multi_instance": false,
   "requirements": {
-    "yunohost": ">= 3.2.0"
+    "yunohost": ">= 3.8.0"
   },
   "services": [
     "nginx",

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -8,135 +8,18 @@ pkg_dependencies="php7.0-fpm sipcalc dnsutils openvpn curl fake-hwclock"
 service_name="ynh-vpnclient"
 service_checker_name=$service_name"-checker"
 
-to_logs() {
-
-  # When yunohost --verbose or bash -x
-  if $_ISVERBOSE; then
-    cat
-  else
-    cat > /dev/null
-  fi
-}
-
-# Experimental helpers
-# Cf. https://github.com/YunoHost-Apps/Experimental_helpers/blob/72b0bc77c68d4a4a2bf4e95663dbc05e4a762a0a/ynh_read_manifest/ynh_read_manifest
-read_json () {
-    python3 -c "import sys, json;print(json.load(open('$1'))['$2'])"
-}
-
-# Experimental helper
-# Cf. https://github.com/YunoHost-Apps/Experimental_helpers/blob/72b0bc77c68d4a4a2bf4e95663dbc05e4a762a0a/ynh_read_manifest/ynh_read_manifest
-read_manifest () {
-    if [ -f '../manifest.json' ] ; then
-        read_json '../manifest.json' "$1"
-    else
-        read_json '../settings/manifest.json' "$1"
-    fi
-}
-
-# Experimental helper
-# cf. https://github.com/YunoHost-Apps/Experimental_helpers/blob/master/ynh_abort_if_up_to_date/ynh_abort_if_up_to_date
-ynh_abort_if_up_to_date () {
-    version=$(read_json "/etc/yunohost/apps/$YNH_APP_INSTANCE_NAME/manifest.json" 'version' 2> /dev/null || echo '20160501-7')
-    last_version=$(read_manifest 'version')
-    if [ "${version}" = "${last_version}" ]; then
-        ynh_print_info "Up-to-date, nothing to do"
-        ynh_die "" 0
-    fi
-}
-
-# Read the value of a key in a ynh manifest file
-#
-# usage: ynh_read_manifest manifest key
-# | arg: manifest - Path of the manifest to read
-# | arg: key - Name of the key to find
-ynh_read_manifest () {
-    manifest="$1"
-    key="$2"
-    python3 -c "import sys, json;print(json.load(open('$manifest', encoding='utf-8'))['$key'])"
-}
-
-# Read the upstream version from the manifest
-# The version number in the manifest is defined by <upstreamversion>~ynh<packageversion>
-# For example : 4.3-2~ynh3
-# This include the number before ~ynh
-# In the last example it return 4.3-2
-#
-# usage: ynh_app_upstream_version
-ynh_app_upstream_version () {
-    manifest_path="../manifest.json"
-    if [ ! -e "$manifest_path" ]; then
-        manifest_path="../settings/manifest.json"   # Into the restore script, the manifest is not at the same place
-    fi
-    version_key=$(ynh_read_manifest "$manifest_path" "version")
-    echo "${version_key/~ynh*/}"
-}
-
-# Read package version from the manifest
-# The version number in the manifest is defined by <upstreamversion>~ynh<packageversion>
-# For example : 4.3-2~ynh3
-# This include the number after ~ynh
-# In the last example it return 3
-#
-# usage: ynh_app_package_version
-ynh_app_package_version () {
-    manifest_path="../manifest.json"
-    if [ ! -e "$manifest_path" ]; then
-        manifest_path="../settings/manifest.json"   # Into the restore script, the manifest is not at the same place
-    fi
-    version_key=$(ynh_read_manifest "$manifest_path" "version")
-    echo "${version_key/*~ynh/}"
-}
-
-# Exit without error if the package is up to date
-#
-# This helper should be used to avoid an upgrade of a package
-# when it's not needed.
-#
-# To force an upgrade, even if the package is up to date,
-# you have to set the variable YNH_FORCE_UPGRADE before.
-# example: YNH_FORCE_UPGRADE=1 yunohost app upgrade MyApp
-#
-# usage: ynh_abort_if_up_to_date
-ynh_abort_if_up_to_date () {
-    local force_upgrade=${YNH_FORCE_UPGRADE:-0}
-    local package_check=${PACKAGE_CHECK_EXEC:-0}
-
-    local version=$(ynh_read_manifest "/etc/yunohost/apps/$YNH_APP_INSTANCE_NAME/manifest.json" "version" || echo 1.0)
-    local last_version=$(ynh_read_manifest "../manifest.json" "version" || echo 1.0)
-    if [ "$version" = "$last_version" ]
-    then
-        if [ "$force_upgrade" != "0" ]
-        then
-            echo "Upgrade forced by YNH_FORCE_UPGRADE." >&2
-            unset YNH_FORCE_UPGRADE
-        elif [ "$package_check" != "0" ]
-        then
-            echo "Upgrade forced for package check." >&2
-        else
-            ynh_die "Up-to-date, nothing to do" 0
-        fi
-    fi
-}
-
 # Operations needed by both 'install' and 'upgrade' scripts
 function vpnclient_deploy_files_and_services()
 {
-  local domain=$1
-  local app=$2
-  local service_name=$3
-  local sysuser="${app}"
-  local service_checker_name="$service_name-checker"
-
   # Ensure vpnclient_ynh has its own system user
-  if ! ynh_system_user_exists ${sysuser}
+  if ! ynh_system_user_exists ${app}
   then
-    ynh_system_user_create ${sysuser}
+    ynh_system_user_create ${app}
   fi
 
   # Ensure the system user has enough permissions
   install -b -o root -g root -m 0440 ../conf/sudoers.conf /etc/sudoers.d/${app}_ynh
-  ynh_replace_string "__VPNCLIENT_SYSUSER__" "${sysuser}" /etc/sudoers.d/${app}_ynh
+  ynh_replace_string "__VPNCLIENT_SYSUSER__" "${app}" /etc/sudoers.d/${app}_ynh
 
   # Install IPv6 scripts
   install -o root -g root -m 0755 ../conf/ipv6_expanded /usr/local/bin/
@@ -147,11 +30,11 @@ function vpnclient_deploy_files_and_services()
 
   # Copy confs
   mkdir -pm 0755 /var/log/nginx/
-  chown root:${sysuser} /etc/openvpn/
+  chown root:${app} /etc/openvpn/
   chmod 775 /etc/openvpn/
   mkdir -pm 0755 /etc/yunohost/hooks.d/post_iptable_rules/
 
-  install -b -o root -g ${sysuser} -m 0664 ../conf/openvpn_client.conf.tpl /etc/openvpn/client.conf.tpl
+  install -b -o root -g ${app} -m 0664 ../conf/openvpn_client.conf.tpl /etc/openvpn/client.conf.tpl
   install -o root -g root -m 0644 ../conf/openvpn_client.conf.tpl /etc/openvpn/client.conf.tpl.restore
   install -b -o root -g root -m 0755 ../conf/hook_post-iptable-rules /etc/yunohost/hooks.d/90-vpnclient.tpl
   install -b -o root -g root -m 0644 ../conf/openvpn@.service /etc/systemd/system/
@@ -166,7 +49,7 @@ function vpnclient_deploy_files_and_services()
 
   # Create certificates directory
   mkdir -pm 0770 /etc/openvpn/keys/
-  chown root:${sysuser} /etc/openvpn/keys/
+  chown root:${app} /etc/openvpn/keys/
 
   #=================================================
   # NGINX CONFIGURATION
@@ -193,6 +76,8 @@ function vpnclient_deploy_files_and_services()
   # Copy checker timer
   install -o root -g root -m 0755 ../conf/$service_checker_name.sh /usr/local/bin/
   install -o root -g root -m 0644 ../conf/$service_checker_name.timer /etc/systemd/system/
+
+  systemctl daemon-reload
 
   #=================================================
   # SETUP SYSTEMD

--- a/scripts/install
+++ b/scripts/install
@@ -23,8 +23,8 @@
 # IMPORT GENERIC HELPERS
 #=================================================
 
-source /usr/share/yunohost/helpers
 source _common.sh
+source /usr/share/yunohost/helpers
 
 #=================================================
 # MANAGE SCRIPT FAILURE
@@ -76,7 +76,7 @@ ynh_install_app_dependencies "$pkg_dependencies"
 #=================================================
 ynh_print_info "Deploy files from package..."
 
-vpnclient_deploy_files_and_services "${domain}" "${app}" "${service_name}"
+vpnclient_deploy_files_and_services
 
 #=================================================
 # RELOAD SERVICES
@@ -88,9 +88,6 @@ ynh_print_info "Reloading services..."
 # and the vpnclient service handles them.
 systemctl disable openvpn
 systemctl stop openvpn
-
-systemctl restart php7.0-fpm
-systemctl reload nginx
 
 # main service
 

--- a/scripts/install
+++ b/scripts/install
@@ -99,9 +99,8 @@ yunohost service enable $service_name
 
 # checker service
 
-yunohost service add $service_checker_name --description "Makes sure that the VPN service is running" --need_lock
-yunohost service start $service_checker_name
-yunohost service enable $service_checker_name
+systemctl start $service_checker_name
+systemctl enable $service_checker_name
 systemctl start $service_checker_name.timer
 systemctl enable $service_checker_name.timer
 

--- a/scripts/remove
+++ b/scripts/remove
@@ -91,6 +91,9 @@ ynh_secure_remove /etc/systemd/system/openvpn@.service
 # Remove openvpn certificates
 ynh_secure_remove /etc/openvpn/keys
 
+# Reload systemd configuration
+systemctl daemon-reload
+
 #=================================================
 # REMOVE DEPENDENCIES
 #=================================================
@@ -99,15 +102,6 @@ ynh_remove_app_dependencies
 
 # Remove sources
 ynh_secure_remove "/var/www/${app}"
-
-# Reload systemd configuration
-systemctl daemon-reload
-
-# Restart services
-# (this must happen before deleting the user, otherwise the user is
-# being used by one of the php pool process)
-systemctl restart php7.0-fpm
-systemctl reload nginx
 
 #=================================================
 # REMOVE DEDICATED USER

--- a/scripts/remove
+++ b/scripts/remove
@@ -39,15 +39,17 @@ domain=$(ynh_app_setting_get $app domain)
 #=================================================
 ynh_print_info "Stopping and removing services"
 
-yunohost service stop $service_checker_name
-yunohost service disable $service_checker_name
-yunohost service remove $service_checker_name
+systemctl stop $service_checker_name
+systemctl disable $service_checker_name
 systemctl stop $service_checker_name.timer && sleep 1
 systemctl disable $service_checker_name.timer
 
-yunohost service stop $service_name
-yunohost service disable $service_name
-yunohost service remove $service_name
+if ynh_exec_warn_less yunohost service status $service_name >/dev/null
+then
+    yunohost service stop $service_name
+    yunohost service disable $service_name
+    yunohost service remove $service_checker
+fi
 
 for FILE in $(ls /etc/systemd/system/$service_name* /usr/local/bin/ynh-vpnclient* /tmp/.ynh-vpnclient-*)
 do

--- a/scripts/restore
+++ b/scripts/restore
@@ -125,7 +125,7 @@ yunohost service add $service_name --description "Tunnels the internet traffic t
 #=================================================
 ynh_print_info "Reloading nginx web server and php-fpm..."
 
-systemctl restart php7.0-fpm
+systemctl reload php7.0-fpm
 systemctl reload nginx
 
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -117,7 +117,6 @@ systemctl enable "openvpn@.service"
 #=================================================
 
 yunohost service add $service_name --description "Tunnels the internet traffic through a VPN" --need_lock
-yunohost service add $service_checker_name --description "Makes sure that the VPN service is running" --need_lock
 
 #=================================================
 # GENERIC FINALIZATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -32,10 +32,10 @@ if [ -f /etc/nginx/conf.d/${domain}.d/vpnadmin.conf ]; then
   mv /etc/nginx/conf.d/${domain}.d/vpnadmin.conf /etc/nginx/conf.d/${domain}.d/${app}.conf
 fi
 
-if [ -f /etc/php5/fpm/pool.d/vpnadmin.conf ]; then
-  ynh_replace_string "/var/www/vpnadmin/" "/var/www/${app}/" /etc/php5/fpm/pool.d/vpnadmin.conf
-  ynh_replace_string "vpnadmin.sock" "${app}.sock"  /etc/php5/fpm/pool.d/vpnadmin.conf
-  mv /etc/php5/fpm/pool.d/vpnadmin.conf /etc/php/7.0/fpm/pool.d/${app}.conf
+if [ -f /etc/php/7.0/fpm/pool.d/vpnadmin.conf ]; then
+  ynh_replace_string "/var/www/vpnadmin/" "/var/www/${app}/" /etc/php/7.0/fpm/pool.d/vpnadmin.conf
+  ynh_replace_string "vpnadmin.sock" "${app}.sock"  /etc/php/7.0/fpm/pool.d/vpnadmin.conf
+  mv /etc/php/7.0/fpm/pool.d/vpnadmin.conf /etc/php/7.0/fpm/pool.d/${app}.conf
 fi
 
 if [ -d /var/www/vpnadmin ]; then
@@ -78,19 +78,15 @@ tmpdir=$(mktemp -d /tmp/vpnclient-upgrade-XXX)
 cp -r /etc/openvpn/client* ${tmpdir}
 
 # Deploy files from package
-vpnclient_deploy_files_and_services "${domain}" "${app}" "${service_name}"
+vpnclient_deploy_files_and_services
 
 # Restore previously existing config files
 cp -r ${tmpdir}/client* /etc/openvpn/
 ynh_secure_remove ${tmpdir}
 
 #=================================================
-# RELOAD RELEVANT SERVICES
+# SERVICE INTEGRATION IN YUNOHOST
 #=================================================
-ynh_print_info "Reload services..."
-
-systemctl reload php7.0-fpm
-systemctl reload nginx
 
 ### Make sure that the yunohost services have a description and need-lock enabled
 
@@ -103,32 +99,16 @@ then
     yunohost service remove $service_checker_name
 fi
 
-# Reload systemd configuration
+#=================================================
+# RESTART RELEVANT SERVICES
+#=================================================
+ynh_print_info "Restart services..."
 
-systemctl daemon-reload
+# this is meant to propagate the new files and configs
 
-### Restart services
-
-# restart main service if needed
-
-if systemctl is-active $service_name >/dev/null;
-then
-    yunohost service restart $service_name
-fi
-
-# restart checker service if needed
-
-if systemctl is-active $service_checker_name >/dev/null;
-then
-    yunohost service restart $service_checker_name
-fi
-
-# restart checker service timer
-
-if systemctl is-active $service_name.timer >/dev/null;
-then
-    yunohost service restart $service_checker_name.timer
-fi
+systemctl -q is-active $service_name               && yunohost service restart $service_name
+systemctl -q is-active $service_checker_name       && yunohost service restart $service_checker_name
+systemctl -q is-active $service_checker_name.timer && yunohost service restart $service_checker_name.timer
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -97,8 +97,11 @@ systemctl reload nginx
 # main service
 yunohost service add $service_name --description "Tunnels the internet traffic through a VPN" --need_lock
 
-# checker service
-yunohost service add $service_checker_name --description "Makes sure that the VPN service is running" --need_lock
+# checker service (this service was previously integrated in yunohost but we do not do this anymore)
+if ynh_exec_warn_less yunohost service status $service_checker_name >/dev/null
+then
+    yunohost service remove $service_checker_name
+fi
 
 # Reload systemd configuration
 


### PR DESCRIPTION
Following the release of 3.8 (diagnosis), many people complained that the diagnosis reported the ynh-vpnclient-checker service as "dead" (it was already flagged as dead or similar in the Service screen, but this view was less ... viewed)

Anyway, integrating this service with yunohost ain't really relevant because this is not a "real" service ... its job is only to make sure ynh-vpnclient is up ... but there's no real "status" for ynh-vpnclient-checker ...

So this is a proposal to remove the service integration from yunohost

Also while reading this, started to realize that there are many unecessary / overly complex stuff so proposing a bunch a cleaning ...