### PR TITLE
ynh-vpnclient-checker: use Type=oneshot

### DIFF
--- a/conf/ynh-vpnclient-checker.service
+++ b/conf/ynh-vpnclient-checker.service
@@ -3,9 +3,10 @@ Description=YunoHost VPN Client Checker.
 After=ynh-vpnclient.service
 
 [Service]
-Type=simple
+Type=oneshot
 User=root
 ExecStart=/usr/local/bin/ynh-vpnclient-checker.sh
+Restart=no
 
 [Install]
 WantedBy=default.target

--- a/conf/ynh-vpnclient-checker.sh
+++ b/conf/ynh-vpnclient-checker.sh
@@ -5,5 +5,5 @@ if [[ -e /tmp/.ynh-vpnclient-started ]] || ip route get 1.2.3.4 | grep -q tun0; 
   exit 0
 else
   echo "[INFO] Restarting VPN client service"
-  yunohost service restart ynh-vpnclient &> /dev/null
+  systemctl restart ynh-vpnclient &> /dev/null
 fi

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -19,13 +19,13 @@ function vpnclient_deploy_files_and_services()
   install -b -o root -g root -m 0644 ../conf/openvpn@.service /etc/systemd/system/openvpn@.service.d/override.conf
 
   # Create certificates directory
-  mkdir -pm 0770 /etc/openvpn/keys/
-  chown root:${app} /etc/openvpn/keys/
+  mkdir -pm 0700 /etc/openvpn/keys/
+  chown ${app}:${app} /etc/openvpn/keys/
 
   # Create scripts directory
-  mkdir -pm 0775 /etc/openvpn/scripts
-  mkdir -pm 0775 /etc/openvpn/scripts/route-up.d
-  mkdir -pm 0775 /etc/openvpn/scripts/route-down.d
+  mkdir -pm 0755 /etc/openvpn/scripts
+  mkdir -pm 0755 /etc/openvpn/scripts/route-up.d
+  mkdir -pm 0755 /etc/openvpn/scripts/route-down.d
   install -b -o root -g root -m 0755 ../conf/scripts/run-parts.sh /etc/openvpn/scripts/run-parts.sh
   install -b -o root -g root -m 0755 ../conf/scripts/route-up.d/* /etc/openvpn/scripts/route-up.d/
   install -b -o root -g root -m 0755 ../conf/scripts/route-down.d/* /etc/openvpn/scripts/route-down.d/

--- a/scripts/restore
+++ b/scripts/restore
@@ -17,6 +17,14 @@ mkdir -pm 0755 /etc/yunohost/hooks.d/post_iptable_rules/
 chmod 0755 /etc/systemd/system/openvpn@.service.d/
 chmod 0644 /etc/systemd/system/openvpn@.service.d/override.conf
 
+# Fix config file permissions
+for config_file in /etc/openvpn/client.{cube,ovpn,conf}; do
+  if [[ -f "${config_file}" ]]; then
+    chmod 0600 "${config_file}"
+    chown ${app}:${app} "${config_file}"
+  fi
+done
+
 # Fix file permissions in certificates directory
 chmod 0700 /etc/openvpn/keys/
 chown ${app}:${app} /etc/openvpn/keys/

--- a/scripts/restore
+++ b/scripts/restore
@@ -9,6 +9,25 @@ source /usr/share/yunohost/helpers
 ynh_print_info "Restoring the app files..."
 
 ynh_restore_everything
+
+# Fix file permissions
+chmod 0775 /etc/openvpn/
+chown root:${app} /etc/openvpn/
+mkdir -pm 0755 /etc/yunohost/hooks.d/post_iptable_rules/
+chmod 0755 /etc/systemd/system/openvpn@.service.d/
+chmod 0644 /etc/systemd/system/openvpn@.service.d/override.conf
+
+# Fix file permissions in certificates directory
+chmod 0700 /etc/openvpn/keys/
+chown ${app}:${app} /etc/openvpn/keys/
+find /etc/openvpn/keys -type f -exec chmod 0600 {} \;
+
+# Ensure scripts are executable
+chmod 0755 -R /etc/openvpn/scripts
+chmod 0755 /usr/local/bin/$service_name
+chmod 0755 /usr/local/bin/$service_checker_name.sh
+chmod 0755 /usr/local/bin/$service_name-loadcubefile.sh
+
 #=================================================
 # RESTORE SYSTEMD
 #=================================================


### PR DESCRIPTION
This service has to be run as root, and to avoid being flagged as a warning by the CI it can be switched to Type=oneshot instead of Type=simple.

## Problem

- The CI reports that the systemd services must be run as a specific user instead of root https://ci-apps.yunohost.org/ci/job/23630

## Solution

- But this service must be run as root because it relaunches a system service, and `Type=oneshot` services are not flagged as warning by the package_linter https://github.com/YunoHost/package_linter/commit/172151662428871b989c052786fc9b7750499b66

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
