### PR TITLE
Fix logging of credentials in clear

### DIFF
--- a/config_panel.toml
+++ b/config_panel.toml
@@ -77,11 +77,13 @@ name = "Configuration"
         pattern.regexp = '^[a-zA-Z0-9_\-\\\.@]+$'
         pattern.error = "OpenVPN accept only alphabetic chars and -_\\.@"
         visible = 'config_file && match(config_file,"^\s*auth-user-pass\s")'
+        redact = true
 
         [main.auth.login_passphrase]
         ask = "Password"
         type = "password"
         visible = 'config_file && match(config_file,"^\s*auth-user-pass(\s.*)?$")'
+        redact = true
 
         [main.auth.crt_client_ta]
         ask = "TLS Auth shared secret"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -85,7 +85,7 @@ function read_cube_secretly() {
     secret_value="$default_value"
   elif [[ "$secret_value" == "true" ]]; then
     secret_value=1
-  elif [[ "$setting_value" == "false" ]]; then
+  elif [[ "$secret_value" == "false" ]]; then
     secret_value=0
   # Save file in tmp dir
   elif [[ "$key" == "crt_"* ]]; then

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -71,7 +71,30 @@ function read_cube() {
       setting_value="$tmp_dir/$key"
     fi
   fi
-  echo $setting_value
+  echo "$setting_value"
+}
+
+function read_cube_secretly() {
+  local config_file="$1"
+  local key="$2"
+  local tmp_dir=$(dirname "$config_file")
+  local default_value="${3:-}"
+
+  secret_value="$(jq --raw-output ".$key" "$config_file")"
+  if [[ "$secret_value" == "null" ]]; then
+    secret_value="$default_value"
+  elif [[ "$secret_value" == "true" ]]; then
+    secret_value=1
+  elif [[ "$setting_value" == "false" ]]; then
+    secret_value=0
+  # Save file in tmp dir
+  elif [[ "$key" == "crt_"* ]]; then
+    if [ -n "${secret_value}" ]; then
+      echo "${secret_value}" | sed 's/|/\n/g' > "$tmp_dir/$key"
+      secret_value="$tmp_dir/$key"
+    fi
+  fi
+  echo "$secret_value"
 }
 
 function convert_cube_file()
@@ -86,14 +109,14 @@ function convert_cube_file()
   ip6_net="$(read_cube $config_file ip6_net)"
   ip6_addr="$(read_cube $config_file ip6_addr)"
   ip6_send_over_tun_enabled="$(read_cube $config_file ip6_send_over_tun 0)"
-  login_user="$(read_cube $config_file login_user)"
-  login_passphrase="$(read_cube $config_file login_passphrase)"
+  login_user="$(read_cube_secretly $config_file login_user)"
+  login_passphrase="$(read_cube_secretly $config_file login_passphrase)"
   dns0="$(read_cube $config_file dns0)"
   dns1="$(read_cube $config_file dns1)"
   crt_server_ca="$(read_cube $config_file crt_server_ca)"
   crt_client="$(read_cube $config_file crt_client)"
-  crt_client_key="$(read_cube $config_file crt_client_key)"
-  crt_client_ta="$(read_cube $config_file crt_client_ta)"
+  crt_client_key="$(read_cube_secretly $config_file crt_client_key)"
+  crt_client_ta="$(read_cube_secretly $config_file crt_client_ta)"
 
   if [[ -z "$dns0" && -z "$dns1" ]]; then
     dns_method="yunohost"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -80,7 +80,8 @@ function read_cube_secretly() {
   local tmp_dir=$(dirname "$config_file")
   local default_value="${3:-}"
 
-  secret_value="$(jq --raw-output ".$key" "$config_file")"
+  # NB: This intermediate variable is here and called secret_ to be caught by YunoHost's autorefact mechanism
+  local secret_value="$(jq --raw-output ".$key" "$config_file")"
   if [[ "$secret_value" == "null" ]]; then
     secret_value="$default_value"
   elif [[ "$secret_value" == "true" ]]; then

--- a/scripts/config
+++ b/scripts/config
@@ -75,7 +75,8 @@ EOF
 get__login_user() {
     if [ -s /etc/openvpn/keys/credentials ]
     then
-        login_user_secret="$(sed -n 1p /etc/openvpn/keys/credentials)"
+        # NB: This intermediate variable is here and called _secret to be caught by YunoHost's autorefact mechanism
+        local login_user_secret="$(sed -n 1p /etc/openvpn/keys/credentials)"
         echo "$login_user_secret"
     else
         echo ""

--- a/scripts/config
+++ b/scripts/config
@@ -75,7 +75,8 @@ EOF
 get__login_user() {
     if [ -s /etc/openvpn/keys/credentials ]
     then
-        echo "$(sed -n 1p /etc/openvpn/keys/credentials)"
+        login_user_secret="$(sed -n 1p /etc/openvpn/keys/credentials)"
+        echo "$login_user_secret"
     else
         echo ""
     fi
@@ -84,7 +85,8 @@ get__login_user() {
 get__login_passphrase() {
     if [ -s /etc/openvpn/keys/credentials ]
     then
-        echo "$(sed -n 2p /etc/openvpn/keys/credentials)"
+        login_passphrase_secret="$(sed -n 2p /etc/openvpn/keys/credentials)"
+        echo "$login_passphrase_secret"
     else
         echo ""
     fi

--- a/scripts/config
+++ b/scripts/config
@@ -85,7 +85,8 @@ get__login_user() {
 get__login_passphrase() {
     if [ -s /etc/openvpn/keys/credentials ]
     then
-        login_passphrase_secret="$(sed -n 2p /etc/openvpn/keys/credentials)"
+        # NB: This intermediate variable is here and called _secret to be caught by YunoHost's autorefact mechanism
+        local login_passphrase_secret="$(sed -n 2p /etc/openvpn/keys/credentials)"
         echo "$login_passphrase_secret"
     else
         echo ""


### PR DESCRIPTION
## Problem

The credentials and private keys were stored in Yunohost logs, even when being shared https://paste.yunohost.org. 

## Solution

Make use of the redaction tools provided by Yunohost, that is when the variable contains "secret", or "pass", or "password", the content won't be logged. Here I made a copy of the read_cube function to use a variable "secret_value" to store the data.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
