### PR TITLE
Fix waiting for openvpn client to start

### DIFF
--- a/conf/ynh-vpnclient
+++ b/conf/ynh-vpnclient
@@ -132,10 +132,12 @@ find_last_line_number() {
   local pattern=$1
   local path=$2
 
+  local file_length=$(wc -l "${path}" | cut -d' ' -f 1)
   local match
   # Search in the file from the end until the pattern matches
-  if match=$(tac "${path}" 2>/dev/null | grep -n "${pattern}" -m 1 --line-buffered); then
-    sed 's/:.*//' <<< $match
+  if match=$(tac "${path}" 2>/dev/null | grep -n "${pattern}" -m 1 --line-buffered -a); then
+    line_number=$(sed 's/:.*//' <<< $match)
+    echo $(($file_length-$line_number))
   else
     echo 0
   fi
@@ -198,8 +200,9 @@ case "$action" in
     fi
 
     info "Waiting for tun0 interface to show up"
+    # Get the line number in the log of the last time openvpn-client exited
     openvpn_log_start=$(find_last_line_number "process exiting" /var/log/vpnclient/openvpn-client.log)
-    if ! timeout 180 tail -n-${openvpn_log_start} -f /var/log/vpnclient/openvpn-client.log 2>/dev/null | grep -q "TUN/TAP device tun0 opened"; then
+    if ! timeout 180 tail -n+${openvpn_log_start} -f /var/log/vpnclient/openvpn-client.log 2>/dev/null | grep -q "TUN/TAP device tun0 opened"; then
       error "The VPN client didn't open tun0 interface"
       tail -n 20 /var/log/vpnclient/openvpn-client.log | tee -a $LOGFILE
       critical "Failed to start OpenVPN client"
@@ -214,7 +217,7 @@ case "$action" in
     fi
 
     info "Waiting for VPN client to be ready..."
-    if ! timeout 180 tail -n-${openvpn_log_start} -f /var/log/vpnclient/openvpn-client.log 2>/dev/null | grep -q "Initialization Sequence Completed"; then
+    if ! timeout 180 tail -n+${openvpn_log_start} -f /var/log/vpnclient/openvpn-client.log 2>/dev/null | grep -q "Initialization Sequence Completed"; then
       error "The VPN client didn't complete initiliasation"
       tail -n 20 /var/log/vpnclient/openvpn-client.log | tee -a $LOGFILE
       critical "Failed to start OpenVPN client"

--- a/conf/ynh-vpnclient
+++ b/conf/ynh-vpnclient
@@ -191,6 +191,9 @@ case "$action" in
     sync_time
     check_config
 
+    # Get the line number in the log of the last time openvpn-client exited
+    openvpn_log_start=$(find_last_line_number "process exiting" /var/log/vpnclient/openvpn-client.log)
+
     info "Now actually starting OpenVPN client..."
     if systemctl start openvpn@client.service; then
       success "OpenVPN client started!"
@@ -200,8 +203,6 @@ case "$action" in
     fi
 
     info "Waiting for tun0 interface to show up"
-    # Get the line number in the log of the last time openvpn-client exited
-    openvpn_log_start=$(find_last_line_number "process exiting" /var/log/vpnclient/openvpn-client.log)
     if ! timeout 180 tail -n+${openvpn_log_start} -f /var/log/vpnclient/openvpn-client.log 2>/dev/null | grep -q "TUN/TAP device tun0 opened"; then
       error "The VPN client didn't open tun0 interface"
       tail -n 20 /var/log/vpnclient/openvpn-client.log | tee -a $LOGFILE


### PR DESCRIPTION
## Problem

See https://github.com/YunoHost-Apps/vpnclient_ynh/pull/145

There is still some race condition when the ynh-vpnclient service is waiting for the openvpn-client service to start and open the VPN tunnel. I noticed that in some case, ynh-vpnclient starts watching the logs *after* the openvpn-client service finished, and then it timeouts and fails.

This is because ynh-vpnclient searches the last time the openvpn-client service exited, takes note of the *offset* from the end of the file, and then from this offset, it waits for the service to finish. But since the openvpn-client is running, the log file continues to grow and the offset isn't valid anymore.

## Solution

First, ynh-vpnclient searches in the logs the last time the openvpn-client service exited and it takes note of the line number. Then, it starts the openvpn-client service.

Finally, from this line number in the logs, it waits for the openvpn-client service to finish.

While this method takes longer when the log file is big, it shouldn't have a race condition anymore since we check the whole log file until we find the last time the openvpn-client service exited.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
