### PR TITLE
Fix custom dns cleanup after power loss

### DIFF
--- a/conf/scripts/route-down.d/10-vpnclient-unset-firewall
+++ b/conf/scripts/route-down.d/10-vpnclient-unset-firewall
@@ -36,4 +36,13 @@ if is_firewall_set; then
   ip6tables -w -X vpnclient_in
   ip6tables -w -X vpnclient_out
   ip6tables -w -X vpnclient_fwd
+
+  if ! is_firewall_set; then
+    echo "[ OK ] Firewall rules correctly unset"
+  else
+    echo "[FAIL] Firewall rules are still set" >&2
+    exit 1
+  fi
+else
+  echo "[ OK ] No firewall rules set"
 fi

--- a/conf/scripts/route-down.d/20-vpnclient-unset-dns
+++ b/conf/scripts/route-down.d/20-vpnclient-unset-dns
@@ -11,6 +11,9 @@ is_dns_set() {
   && [[ "$current_dns" == "$wanted_dns" ]]
 }
 
+ynh_dns_method=$(yunohost app setting vpnclient dns_method)
+ynh_dns=$(yunohost app setting vpnclient nameservers)
+
 if is_dns_set; then
   resolvconf=/etc/resolv.dnsmasq.conf
   

--- a/conf/scripts/route-down.d/20-vpnclient-unset-dns
+++ b/conf/scripts/route-down.d/20-vpnclient-unset-dns
@@ -30,7 +30,7 @@ if is_dns_set; then
     cat /usr/share/yunohost/conf/dnsmasq/plain/resolv.dnsmasq.conf | grep "^nameserver" | shuf >${resolvconf}
   fi
 
-  if ! is_dns_set(); then
+  if ! is_dns_set; then
     echo "[ OK ] Custom DNS correctly unset"
   else
     echo "[FAIL] Custom DNS are still set" >&2

--- a/conf/scripts/route-down.d/20-vpnclient-unset-dns
+++ b/conf/scripts/route-down.d/20-vpnclient-unset-dns
@@ -1,10 +1,6 @@
 #!/bin/bash
 
 is_dns_set() {
-  if [[ "$ynh_dns_method" != "custom" ]]; then
-    return 0
-  fi
-
   current_dns=$(grep -o -P '^\s*nameserver\s+\K[abcdefABCDEF\d.:]+$' /etc/resolv.dnsmasq.conf | sort | uniq)
   wanted_dns=$(echo "${ynh_dns}" | sed 's/,/\n/g'  | sort | uniq)
   [[ -e /etc/dhcp/dhclient-exit-hooks.d/ynh-vpnclient ]] \
@@ -12,6 +8,11 @@ is_dns_set() {
 }
 
 ynh_dns_method=$(yunohost app setting vpnclient dns_method)
+if [[ "$ynh_dns_method" != "custom" ]]; then
+  echo "[ OK ] No custom DNS to unset"
+  exit 0
+fi
+
 ynh_dns=$(yunohost app setting vpnclient nameservers)
 
 if is_dns_set; then
@@ -28,4 +29,14 @@ if is_dns_set; then
     # This is the main line from yunohost's dnsmasq hook generating the resolv.dnsmasq.conf
     cat /usr/share/yunohost/conf/dnsmasq/plain/resolv.dnsmasq.conf | grep "^nameserver" | shuf >${resolvconf}
   fi
+
+  if ! is_dns_set(); then
+    echo "[ OK ] Custom DNS correctly unset"
+  else
+    echo "[FAIL] Custom DNS are still set" >&2
+    exit 1
+  fi
+else
+  echo "[ OK ] No custom DNS set"
 fi
+

--- a/conf/scripts/route-up.d/10-vpnclient-set-firewall
+++ b/conf/scripts/route-up.d/10-vpnclient-set-firewall
@@ -13,7 +13,7 @@ fi
 cp /etc/yunohost/apps/vpnclient/conf/hook_post-iptable-rules /etc/yunohost/hooks.d/post_iptable_rules/90-vpnclient
 
 if is_firewall_set; then
-  echo "[ OK ] Firewall rules set"
+  echo "[ OK ] Firewall rules correctly set"
 else
   echo "[FAIL] No firewall rules set" >&2
   exit 1

--- a/conf/scripts/route-up.d/10-vpnclient-set-firewall
+++ b/conf/scripts/route-up.d/10-vpnclient-set-firewall
@@ -13,8 +13,8 @@ fi
 cp /etc/yunohost/apps/vpnclient/conf/hook_post-iptable-rules /etc/yunohost/hooks.d/post_iptable_rules/90-vpnclient
 
 if is_firewall_set; then
-  echo "[ OK ] IPv6/IPv4 firewall set"
+  echo "[ OK ] Firewall rules set"
 else
-  echo "[FAIL] No IPv6/IPv4 firewall set" >&2
+  echo "[FAIL] No firewall rules set" >&2
   exit 1
 fi

--- a/conf/scripts/route-up.d/20-vpnclient-set-dns
+++ b/conf/scripts/route-up.d/20-vpnclient-set-dns
@@ -28,8 +28,8 @@ EOF
 fi
 
 if is_dns_set; then
-  echo "[ OK ] Host DNS correctly set"
+  echo "[ OK ] Custom DNS correctly set"
 else
-  echo "[FAIL] No host DNS set" >&2
+  echo "[FAIL] No custom DNS set" >&2
   exit 1
 fi

--- a/conf/ynh-vpnclient
+++ b/conf/ynh-vpnclient
@@ -186,6 +186,10 @@ case "$action" in
     # but yunohost firewall reload doesn't seem to work currently
     /etc/openvpn/scripts/route-down.d/10-vpnclient-unset-firewall
 
+    # In case custom DNS weren't deleted during last run
+    # (for instance after a crash or power loss)
+    /etc/openvpn/scripts/route-down.d/20-vpnclient-unset-dns
+
     sync_time
     check_config
 

--- a/conf/ynh-vpnclient
+++ b/conf/ynh-vpnclient
@@ -184,11 +184,11 @@ case "$action" in
     # (for instance after a crash or power loss)
     # This could be improved by just removing the vpnclient firewall hook,
     # but yunohost firewall reload doesn't seem to work currently
-    /etc/openvpn/scripts/route-down.d/10-vpnclient-unset-firewall
+    /etc/openvpn/scripts/route-down.d/10-vpnclient-unset-firewall | tee -a $LOGFILE
 
     # In case custom DNS weren't deleted during last run
     # (for instance after a crash or power loss)
-    /etc/openvpn/scripts/route-down.d/20-vpnclient-unset-dns
+    /etc/openvpn/scripts/route-down.d/20-vpnclient-unset-dns | tee -a $LOGFILE
 
     sync_time
     check_config


### PR DESCRIPTION
## Problem

#160 

## Solution

Ensure that custom DNS are removed before starting the VPN client

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
