### PR TITLE
Convert iptables rules to nftables

### DIFF
--- a/conf/hook_post-iptable-rules
+++ b/conf/hook_post-iptable-rules
@@ -1,105 +1,123 @@
 #!/bin/bash
 
+function join_by() {
+  local delimiter="$1"
+  shift
+  sed "s/ /${delimiter}/g" <<< $@
+}
+
+ip4_servers=""
+ip6_servers=""
 if [[ -z "${trusted_ip}" && -z "${trusted_ip6}" ]]; then
-  server_names=$(grep -o -P '^\s*remote\s+\K([^\s]+)' /etc/openvpn/client.conf | sort | uniq)
+  servers=$(grep -o -P '^\s*remote\s+\K([^\s]+)' /etc/openvpn/client.conf | sort | uniq)
 
   # In case an ip has been provided in ovpn conf
-  host4=""
-  host6=""
-  for i in ${server_names}; do
-    if [[ "${i}" =~ : ]]; then
-      host6+=" ${i}"
-    elif [[ "${i}" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-      host4+=" ${i}"
+  for server in ${servers}; do
+    if [[ "${server}" =~ ':' ]]; then
+      ip6_servers+=" ${server}"
+    elif [[ "${server}" =~ '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$' ]]; then
+      ip4_servers+=" ${server}"
     else
-      host6+=" $(dig AAAA +short "${i}" @127.0.0.1 | grep -v '\.$' | grep -v "timed out")"
-      host4+=" $(dig A +short "${i}" @127.0.0.1 | grep -v '\.$' | grep -v "timed out")"
+      ip6_server=$(dig AAAA +short "${server}" @127.0.0.1 | grep -v '\.$' | grep -v "timed out" | tr '\n' ' ')
+      if [[ -n "${ip6_server}" ]]; then
+        ip6_servers+=" ${ip6_server}"
+      fi
+
+      ip4_server=$(dig A +short "${server}" @127.0.0.1 | grep -v '\.$' | grep -v "timed out" | tr '\n' ' ')
+      if [[ -n "${ip4_server}" ]]; then
+        ip4_servers+=" ${ip4_server}"
+      fi
     fi
   done
 else
   if [[ -n "${trusted_ip6}" ]]; then
-    host6=${trusted_ip6}
+    ip6_servers="${trusted_ip6}"
   fi
 
   if [[ -n "${trusted_ip}" ]]; then
-    host4=${trusted_ip}
+    ip4_servers="${trusted_ip}"
   fi
 fi
+
+ip6_servers=$(join_by ', ' ${ip6_servers})
+ip4_servers=$(join_by ', ' ${ip4_servers})
 
 wired_device=$(ip route | awk '/default via/ { print $5; }')
-dns=$(grep -o -P '^\s*nameserver\s+\K[a-fA-F\d.:]+$' /etc/resolv.dnsmasq.conf | sort | uniq)
+
+ip6_dns=""
+ip4_dns=""
+for dns in $(grep -o -P '^\s*nameserver\s+\K[a-fA-F\d.:]+$' /etc/resolv.dnsmasq.conf | sort -u); do
+  if [[ "${dns}" =~ ':' ]]; then
+    ip6_dns+=" ${dns}"
+  else
+    ip4_dns+=" ${dns}"
+  fi
+done
+
+ip6_dns=$(join_by ', ' ${ip6_dns})
+ip4_dns=$(join_by ', ' ${ip4_dns})
 
 # IPv6
+nft -f - << EOF
+define ip6_dns = { ${ip6_dns} }
+define ip4_dns = { ${ip4_dns} }
+define ip6_local = { fd00::/8, fe80::/10 }
+define ip4_local = { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16 }
 
-ip6tables -w -N vpnclient_in
-ip6tables -w -N vpnclient_out
-ip6tables -w -N vpnclient_fwd
+table inet filter {
+  chain vpnclient_in {
+    ip6 saddr \$ip6_local counter accept comment "accept traffic from local ipv6"
+    ip saddr \$ip4_local counter accept comment "accept traffic from local ipv4"
 
-ip6tables -w -A vpnclient_in -p icmpv6 -j ACCEPT
-ip6tables -w -A vpnclient_in -s fd00::/8,fe80::/10 -j ACCEPT
-ip6tables -w -A vpnclient_in -p tcp --dport 22 -j ACCEPT
-ip6tables -w -A vpnclient_in -p tcp --dport 443 -j ACCEPT
-ip6tables -w -A vpnclient_in -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-ip6tables -w -A vpnclient_in -j DROP
+    tcp dport ssh counter accept comment "accept traffic to ssh port"
+    tcp dport https counter accept comment "accept traffic to https port"
 
-if [[ ! -z "${host6}" ]]; then
-  for i in ${host6}; do
-    ip6tables -w -A vpnclient_out -d "${i}" -j ACCEPT
-  done
-fi
+    ip6 nexthdr icmpv6 counter accept
+    ip protocol icmp counter accept
+    ct state related,established counter accept
 
-for i in ${dns}; do
-  if [[ "${i}" =~ : ]]; then
-    ip6tables -w -A vpnclient_out -p udp -d "${i}" --dport 53 -j ACCEPT
-  fi
-done
+    counter drop
+  }
 
-ip6tables -w -A vpnclient_out -d fd00::/8,fe80::/10 -j ACCEPT
-ip6tables -w -A vpnclient_out -p icmpv6 -j ACCEPT
-ip6tables -w -A vpnclient_out -p udp --dport 5353 -d ff02::fb -j ACCEPT
-ip6tables -w -A vpnclient_out -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-ip6tables -w -A vpnclient_out -j DROP
+  chain vpnclient_out {
+    ip6 daddr { $ip6_servers } counter accept
+    ip daddr { $ip4_servers } counter accept
 
-ip6tables -w -A vpnclient_fwd -j DROP
+    ip6 daddr \$ip6_dns udp dport 53 counter accept comment "accept traffic to DNS nameservers"
+    ip daddr \$ip4_dns udp dport 53 counter accept comment "accept traffic to DNS nameservers"
 
-ip6tables -w -I INPUT 1 -i $wired_device -j vpnclient_in
-ip6tables -w -I OUTPUT 1 -o $wired_device -j vpnclient_out
-ip6tables -w -I FORWARD 1 -o $wired_device -j vpnclient_fwd
+    ip6 daddr \$ip6_local counter accept comment "accept traffic to local ipv6"
+    ip daddr \$ip4_local counter accept comment "accept traffic to local ipv4"
 
-# IPv4
+    ip6 daddr ff02::fb udp dport 5353 counter accept
+    ip daddr 224.0.0.251 udp dport 5353 counter accept
 
-iptables -w -N vpnclient_in
-iptables -w -N vpnclient_out
-iptables -w -N vpnclient_fwd
+    ip6 nexthdr icmpv6 counter accept
+    ip protocol icmp counter accept
+    ct state related,established counter accept
 
-iptables -w -A vpnclient_in -p icmp -j ACCEPT
-iptables -w -A vpnclient_in -s 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.0.0/16 -j ACCEPT
-iptables -w -A vpnclient_in -p tcp --dport 22 -j ACCEPT
-iptables -w -A vpnclient_in -p tcp --dport 443 -j ACCEPT
-iptables -w -A vpnclient_in -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-iptables -w -A vpnclient_in -j DROP
+    counter drop
+  }
 
-if [[ ! -z "${host4}" ]]; then
-  for i in ${host4}; do
-    iptables -w -A vpnclient_out -d "${i}" -j ACCEPT
-  done
-fi
+  chain vpnclient_fwd {
+    counter drop
+  }
 
-for i in ${dns}; do
-  if [[ "${i}" =~ \. ]]; then
-    iptables -w -A vpnclient_out -p udp -d "${i}" --dport 53 -j ACCEPT
-  fi
-done
+  chain input {
+    type filter hook input priority 0; policy accept
+    iifname "$wired_device" counter jump vpnclient_in
+  }
 
-iptables -w -A vpnclient_out -d 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.0.0/16 -j ACCEPT
-iptables -w -A vpnclient_out -p udp --dport 5353 -d 224.0.0.251 -j ACCEPT
-iptables -w -A vpnclient_out -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-iptables -w -A vpnclient_out -j DROP
+  chain output {
+    type filter hook output priority 0; policy accept
+    oifname "$wired_device" counter jump vpnclient_out
+  }
 
-iptables -w -A vpnclient_fwd -j DROP
-
-iptables -w -I INPUT 1 -i $wired_device -j vpnclient_in
-iptables -w -I OUTPUT 1 -o $wired_device -j vpnclient_out
-iptables -w -I FORWARD 1 -o  $wired_device -j vpnclient_fwd
+  chain forward {
+    type filter hook forward priority 0; policy accept
+    oifname "$wired_device" counter jump vpnclient_fwd
+  }
+}
+EOF
 
 exit 0

--- a/conf/hook_post-iptable-rules
+++ b/conf/hook_post-iptable-rules
@@ -42,6 +42,15 @@ fi
 ip6_servers=$(join_by ', ' ${ip6_servers})
 ip4_servers=$(join_by ', ' ${ip4_servers})
 
+ip6_servers_rule=""
+if [[ -n $ip6_servers ]]; then
+  ip6_servers_rule="ip6 daddr { $ip6_servers } counter accept"
+fi
+ip4_servers_rule=""
+if [[ -n $ip4_servers ]]; then
+  ip4_servers_rule="ip daddr { $ip4_servers } counter accept"
+fi
+
 wired_device=$(ip route | awk '/default via/ { print $5; exit; }')
 
 ip6_dns=""
@@ -80,8 +89,8 @@ table inet filter {
   }
 
   chain vpnclient_out {
-    ip6 daddr { $ip6_servers } counter accept
-    ip daddr { $ip4_servers } counter accept
+    $ip6_servers_rule
+    $ip4_servers_rule
 
     ip6 daddr \$ip6_dns udp dport 53 counter accept comment "accept traffic to DNS nameservers"
     ip daddr \$ip4_dns udp dport 53 counter accept comment "accept traffic to DNS nameservers"

--- a/conf/hook_post-iptable-rules
+++ b/conf/hook_post-iptable-rules
@@ -89,8 +89,8 @@ table inet filter {
     ip6 daddr \$ip6_local counter accept comment "accept traffic to local ipv6"
     ip daddr \$ip4_local counter accept comment "accept traffic to local ipv4"
 
-    ip6 daddr ff02::fb udp dport 5353 counter accept
-    ip daddr 224.0.0.251 udp dport 5353 counter accept
+    ip6 daddr ff02::fb udp dport 5353 counter accept comment "accept traffic to bonjour protocol ipv6"
+    ip daddr 224.0.0.251 udp dport 5353 counter accept comment "accept traffic to bonjour protocol ipv4"
 
     ip6 nexthdr icmpv6 counter accept
     ip protocol icmp counter accept

--- a/conf/hook_post-iptable-rules
+++ b/conf/hook_post-iptable-rules
@@ -42,7 +42,7 @@ fi
 ip6_servers=$(join_by ', ' ${ip6_servers})
 ip4_servers=$(join_by ', ' ${ip4_servers})
 
-wired_device=$(ip route | awk '/default via/ { print $5; }')
+wired_device=$(ip route | awk '/default via/ { print $5; exit; }')
 
 ip6_dns=""
 ip4_dns=""

--- a/conf/hook_post-iptable-rules
+++ b/conf/hook_post-iptable-rules
@@ -66,7 +66,6 @@ done
 ip6_dns=$(join_by ', ' ${ip6_dns})
 ip4_dns=$(join_by ', ' ${ip4_dns})
 
-# IPv6
 nft -f - << EOF
 define ip6_dns = { ${ip6_dns} }
 define ip4_dns = { ${ip4_dns} }

--- a/conf/optional-scripts/route-up.d/50-vpnclient-set-ipv6-send-over-tun
+++ b/conf/optional-scripts/route-up.d/50-vpnclient-set-ipv6-send-over-tun
@@ -23,8 +23,6 @@ if [[ -n "${net_gateway_ipv6}" ]]; then
 
   echo "[INFO] Found IPv6 address: ${ip6_addr}"
 
-  mkdir -p /etc/iproute2/rt_tables.d
-  
   echo "1 send_over_tun" > /etc/iproute2/rt_tables.d/vpnclient_ynh.conf
   ip -6 route flush table send_over_tun || true
   ip -6 route add default via "${ip6_gw}" dev "${gateway_interface}" table send_over_tun proto static

--- a/conf/optional-scripts/route-up.d/50-vpnclient-set-ipv6-send-over-tun
+++ b/conf/optional-scripts/route-up.d/50-vpnclient-set-ipv6-send-over-tun
@@ -23,6 +23,8 @@ if [[ -n "${net_gateway_ipv6}" ]]; then
 
   echo "[INFO] Found IPv6 address: ${ip6_addr}"
 
+  mkdir -p /etc/iproute2/rt_tables.d
+  
   echo "1 send_over_tun" > /etc/iproute2/rt_tables.d/vpnclient_ynh.conf
   ip -6 route flush table send_over_tun || true
   ip -6 route add default via "${ip6_gw}" dev "${gateway_interface}" table send_over_tun proto static

--- a/conf/scripts/route-down.d/10-vpnclient-unset-firewall
+++ b/conf/scripts/route-down.d/10-vpnclient-unset-firewall
@@ -23,8 +23,8 @@ wired_device=$(ip route | awk '/default via/ { print $5; exit; }')
 rm -f /etc/yunohost/hooks.d/post_iptable_rules/90-vpnclient
 if is_firewall_set; then  
   delete_nft_rule "input" "iifname \"${wired_device}\" jump vpnclient_in"
-  delete_nft_rule "output" "iifname \"${wired_device}\" jump vpnclient_out"
-  delete_nft_rule "forward" "iifname \"${wired_device}\" jump vpnclient_fwd"
+  delete_nft_rule "output" "oifname \"${wired_device}\" jump vpnclient_out"
+  delete_nft_rule "forward" "oifname \"${wired_device}\" jump vpnclient_fwd"
 
   nft flush chain inet filter vpnclient_in
   nft flush chain inet filter vpnclient_out

--- a/conf/scripts/route-down.d/10-vpnclient-unset-firewall
+++ b/conf/scripts/route-down.d/10-vpnclient-unset-firewall
@@ -1,41 +1,38 @@
 #!/bin/bash
 
 is_firewall_set() {
-  ip6tables -w -nvL OUTPUT | grep vpnclient_out | grep -q "${wired_device}" \
-  && iptables -w -nvL OUTPUT | grep vpnclient_out | grep -q "${wired_device}"
+  nft list chain inet filter output | grep vpnclient_out | grep -q "${wired_device}"
 }
 
-wired_device=$(ip route | awk '/default via/ { print $5; }')
+delete_nft_rule() {
+  local chain=$1
+  shift
+  local rule=$@
+
+  handle=$(nft -a list chain inet filter "${chain}" | sed -E 's/\s*counter packets [0-9]+ bytes [0-9]+\s*/ /g' | grep "${rule}" | grep -Po 'handle \K\d+')
+  if [[ -n "${handle}" ]]; then
+    nft delete rule inet filter "${chain}" handle "$handle"
+  else
+    >&2 echo "Cannot remove rule in chain ${chain}: ${rule} doesn't exist"
+    return 1
+  fi
+}
+
+wired_device=$(ip route | awk '/default via/ { print $5; exit; }')
 
 rm -f /etc/yunohost/hooks.d/post_iptable_rules/90-vpnclient
 if is_firewall_set; then  
-  # IPv4
+  delete_nft_rule "input" "iifname \"${wired_device}\" jump vpnclient_in"
+  delete_nft_rule "output" "iifname \"${wired_device}\" jump vpnclient_out"
+  delete_nft_rule "forward" "iifname \"${wired_device}\" jump vpnclient_fwd"
 
-  iptables -w -D INPUT -i "${wired_device}" -j vpnclient_in
-  iptables -w -D OUTPUT -o "${wired_device}" -j vpnclient_out
-  iptables -w -D FORWARD -o "${wired_device}" -j vpnclient_fwd
+  nft flush chain inet filter vpnclient_in
+  nft flush chain inet filter vpnclient_out
+  nft flush chain inet filter vpnclient_fwd
 
-  iptables -w -F vpnclient_in
-  iptables -w -F vpnclient_out
-  iptables -w -F vpnclient_fwd
-
-  iptables -w -X vpnclient_in
-  iptables -w -X vpnclient_out
-  iptables -w -X vpnclient_fwd
-
-  # IPv6
-  
-  ip6tables -w -D INPUT -i "${wired_device}" -j vpnclient_in
-  ip6tables -w -D OUTPUT -o "${wired_device}" -j vpnclient_out
-  ip6tables -w -D FORWARD -o "${wired_device}" -j vpnclient_fwd
-
-  ip6tables -w -F vpnclient_in
-  ip6tables -w -F vpnclient_out
-  ip6tables -w -F vpnclient_fwd
-
-  ip6tables -w -X vpnclient_in
-  ip6tables -w -X vpnclient_out
-  ip6tables -w -X vpnclient_fwd
+  nft delete chain inet filter vpnclient_in
+  nft delete chain inet filter vpnclient_out
+  nft delete chain inet filter vpnclient_fwd
 
   if ! is_firewall_set; then
     echo "[ OK ] Firewall rules correctly unset"

--- a/conf/scripts/route-down.d/30-vpnclient-unset-server-ipv6-route
+++ b/conf/scripts/route-down.d/30-vpnclient-unset-server-ipv6-route
@@ -20,7 +20,7 @@ unset_serverip6route() {
   ip route delete "${server_ip6}/128" via "${ip6_gw}" dev "${wired_device}"
 }
 
-wired_device=$(ip route | awk '/default via/ { print $5; }')
+wired_device=$(ip route | awk '/default via/ { print $5; exit; }')
 
 # See https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/#environmental-variables
 # to have a list of variables provided by OpenVPN, i.e:

--- a/conf/scripts/route-up.d/10-vpnclient-set-firewall
+++ b/conf/scripts/route-up.d/10-vpnclient-set-firewall
@@ -1,10 +1,9 @@
 #!/bin/bash
 
 is_firewall_set() {
-  local wired_device=$(ip route | awk '/default via/ { print $5; }')
+  local wired_device=$(ip route | awk '/default via/ { print $5; exit; }')
 
-  ip6tables -w -nvL OUTPUT | grep vpnclient_out | grep -q "${wired_device}" \
-  && iptables -w -nvL OUTPUT | grep vpnclient_out | grep -q "${wired_device}"
+  nft list chain inet filter output | grep vpnclient_out | grep -q "${wired_device}"
 }
 
 if ! is_firewall_set; then

--- a/conf/scripts/route-up.d/30-vpnclient-set-server-ipv6-route
+++ b/conf/scripts/route-up.d/30-vpnclient-set-server-ipv6-route
@@ -20,7 +20,7 @@ set_serverip6route() {
   ip route add "${server_ip6}/128" via "${ip6_gw}" dev "${wired_device}"
 }
 
-wired_device=$(ip route | awk '/default via/ { print $5; }')
+wired_device=$(ip route | awk '/default via/ { print $5; exit; }')
 
 # See https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/#environmental-variables
 # to have a list of variables provided by OpenVPN, i.e:

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -30,6 +30,11 @@ function vpnclient_deploy_files_and_services()
   install -b -o root -g root -m 0755 ../conf/scripts/route-up.d/* /etc/openvpn/scripts/route-up.d/
   install -b -o root -g root -m 0755 ../conf/scripts/route-down.d/* /etc/openvpn/scripts/route-down.d/
 
+  if [[ ${ip6_send_over_tun_enabled} -eq 1 ]]; then
+    install -b -o root -g root -m 0755 ../conf/optional-scripts/route-up.d/50-vpnclient-set-ipv6-send-over-tun /etc/openvpn/scripts/route-up.d/
+    install -b -o root -g root -m 0755 ../conf/optional-scripts/route-down.d/50-vpnclient-unset-ipv6-send-over-tun /etc/openvpn/scripts/route-down.d/
+  fi
+
   #=================================================
 
   # Copy init script

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -22,6 +22,9 @@ function vpnclient_deploy_files_and_services()
   mkdir -pm 0700 /etc/openvpn/keys/
   chown ${app}:${app} /etc/openvpn/keys/
 
+  # Create iproute2 directory
+  mkdir -p /etc/iproute2/rt_tables.d
+
   # Create scripts directory
   mkdir -pm 0755 /etc/openvpn/scripts
   mkdir -pm 0755 /etc/openvpn/scripts/route-up.d

--- a/scripts/install
+++ b/scripts/install
@@ -3,6 +3,8 @@
 source _common.sh
 source /usr/share/yunohost/helpers
 
+ip6_send_over_tun_enabled=0
+
 # Default values for config panel
 ynh_app_setting_set --key="service_enabled" --value="0"
 ynh_app_setting_set --key="config_file" --value=""
@@ -12,7 +14,7 @@ ynh_app_setting_set --key="dns_method" --value="yunohost"
 ynh_app_setting_set --key="nameservers" --value=""
 ynh_app_setting_set --key="ip6_addr" --value=""
 ynh_app_setting_set --key="ip6_net" --value=""
-ynh_app_setting_set --key="ip6_send_over_tun_enabled" --value="0"
+ynh_app_setting_set --key="ip6_send_over_tun_enabled" --value="${ip6_send_over_tun_enabled}"
 
 #=================================================
 # DEPLOY FILES FROM PACKAGE


### PR DESCRIPTION
## Problem

In fresh install, iptables might not be available. Thus, the firewall rules aren't applied… 

## Solution

The idea is to migrate the current iptables to nftables. This is a first draft, I didn't test the rules on a server yet.


## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
